### PR TITLE
Restore detached BodyNodes to original skeleton

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Physics 1.x.x (20XX-XX-XX)
 
+1. Restore detached BodyNodes to original skeleton
+    * [Pull request 42](https://github.com/ignitionrobotics/ign-physics/pull/42)
+
 1. Fix collision issue with detachable joints
     * [Pull request 31](https://github.com/ignitionrobotics/ign-physics/pull/31)
 

--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -56,6 +56,10 @@ struct ModelInfo
 struct LinkInfo
 {
   dart::dynamics::BodyNodePtr link;
+  /// \brief It may be necessary for dartsim to rename a BodyNode (eg. when
+  /// moving the BodyNode to a new skeleton), so we store the Gazebo-specified
+  /// name of the Link here.
+  std::string name;
 };
 
 struct JointInfo
@@ -122,6 +126,16 @@ struct EntityStorage
   const Value1 &at(const std::size_t _id) const
   {
     return idToObject.at(_id);
+  }
+
+  Value1 &at(const Key2 &_key)
+  {
+    return idToObject.at(objectToID.at(_key));
+  }
+
+  const Value1 &at(const Key2 &_key) const
+  {
+    return idToObject.at(objectToID.at(_key));
   }
 
   std::size_t size() const
@@ -274,6 +288,9 @@ class Base : public Implements3d<FeatureList<Feature>>
     const std::size_t id = this->GetNextEntity();
     this->links.idToObject[id] = std::make_shared<LinkInfo>();
     this->links.idToObject[id]->link = _bn;
+    // The name of the BodyNode during creation is assumed to be the
+    // Gazebo-specified name.
+    this->links.idToObject[id]->name = _bn->getName();
     this->links.objectToID[_bn] = id;
     this->frames[id] = _bn;
 

--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -321,7 +321,7 @@ Identity EntityManagementFeatures::GetJoint(
 const std::string &EntityManagementFeatures::GetLinkName(
     const Identity &_linkID) const
 {
-  return this->ReferenceInterface<LinkInfo>(_linkID)->link->getName();
+  return this->ReferenceInterface<LinkInfo>(_linkID)->name;
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -156,7 +156,56 @@ void JointFeatures::DetachJoint(const Identity &_jointId)
       child->getSpatialVelocity(
           dart::dynamics::Frame::World(),
           dart::dynamics::Frame::World());
-  auto freeJoint = child->moveTo<dart::dynamics::FreeJoint>(nullptr);
+
+  if (!this->links.HasEntity(child))
+  {
+    return;
+  }
+
+  auto childLinkInfo = this->links.at(child);
+
+  dart::dynamics::SkeletonPtr skeleton;
+  {
+    // Find the original skeleton the child BodyNode belonged to
+    std::string oldName = child->getName();
+    if (oldName != childLinkInfo->name)
+    {
+      std::size_t originalNameIndex = oldName.rfind(childLinkInfo->name);
+      if (originalNameIndex > 1 && originalNameIndex != std::string::npos &&
+          this->models.HasEntity(joint->getSkeleton()))
+      {
+        // Assume that the original and the current skeletons are in the same
+        // world.
+        auto worldId =
+          this->models
+          .idToContainerID[this->models.IdentityOf(joint->getSkeleton())];
+        auto dartWorld = this->worlds.at(worldId);
+        std::string modelName = oldName.substr(0, originalNameIndex - 1);
+        skeleton = dartWorld->getSkeleton(modelName);
+        if (skeleton)
+        {
+          child->setName(childLinkInfo->name);
+        }
+      }
+      if (nullptr == skeleton)
+      {
+        ignerr << "Could not find the original skeleton of BodyNode "
+               << "[" << oldName << "] when detaching joint "
+               << "[" << joint->getName() << "]. Detached links may not work "
+               << "as expected.\n";
+      }
+    }
+  }
+
+  dart::dynamics::FreeJoint *freeJoint;
+  if (skeleton)
+  {
+    freeJoint = child->moveTo<dart::dynamics::FreeJoint>(skeleton, nullptr);
+  }
+  else
+  {
+    freeJoint = child->moveTo<dart::dynamics::FreeJoint>(nullptr);
+  }
   freeJoint->setTransform(transform);
   freeJoint->setSpatialVelocity(spatialVelocity,
           dart::dynamics::Frame::World(),
@@ -186,8 +235,8 @@ Identity JointFeatures::AttachFixedJoint(
     const BaseLink3dPtr &_parent,
     const std::string &_name)
 {
-  DartBodyNode *const bn =
-      this->ReferenceInterface<LinkInfo>(_childID)->link.get();
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_childID);
+  DartBodyNode *const bn = linkInfo->link.get();
   dart::dynamics::WeldJoint::Properties properties;
   properties.mName = _name;
 
@@ -201,6 +250,13 @@ Identity JointFeatures::AttachFixedJoint(
     return this->GenerateInvalidId();
   }
 
+  {
+    auto skeleton = bn->getSkeleton();
+    if (skeleton)
+    {
+      bn->setName(skeleton->getName() + '/' + linkInfo->name);
+    }
+  }
   const std::size_t jointID = this->AddJoint(
       bn->moveTo<dart::dynamics::WeldJoint>(parentBn, properties));
   // TODO(addisu) Remove incrementVersion once DART has been updated to
@@ -270,8 +326,8 @@ Identity JointFeatures::AttachRevoluteJoint(
     const std::string &_name,
     const AngularVector3d &_axis)
 {
-  DartBodyNode *const bn =
-      this->ReferenceInterface<LinkInfo>(_childID)->link.get();
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_childID);
+  DartBodyNode *const bn = linkInfo->link.get();
   dart::dynamics::RevoluteJoint::Properties properties;
   properties.mName = _name;
   properties.mAxis = _axis;
@@ -286,6 +342,13 @@ Identity JointFeatures::AttachRevoluteJoint(
     return this->GenerateInvalidId();
   }
 
+  {
+    auto skeleton = bn->getSkeleton();
+    if (skeleton)
+    {
+      bn->setName(skeleton->getName() + '/' + linkInfo->name);
+    }
+  }
   const std::size_t jointID = this->AddJoint(
       bn->moveTo<dart::dynamics::RevoluteJoint>(parentBn, properties));
   // TODO(addisu) Remove incrementVersion once DART has been updated to
@@ -332,8 +395,8 @@ Identity JointFeatures::AttachPrismaticJoint(
     const std::string &_name,
     const LinearVector3d &_axis)
 {
-  DartBodyNode *const bn =
-      this->ReferenceInterface<LinkInfo>(_childID)->link.get();
+  auto linkInfo = this->ReferenceInterface<LinkInfo>(_childID);
+  DartBodyNode *const bn = linkInfo->link.get();
   dart::dynamics::PrismaticJoint::Properties properties;
   properties.mName = _name;
   properties.mAxis = _axis;
@@ -348,6 +411,13 @@ Identity JointFeatures::AttachPrismaticJoint(
     return this->GenerateInvalidId();
   }
 
+  {
+    auto skeleton = bn->getSkeleton();
+    if (skeleton)
+    {
+      bn->setName(skeleton->getName() + '/' + linkInfo->name);
+    }
+  }
   const std::size_t jointID = this->AddJoint(
       bn->moveTo<dart::dynamics::PrismaticJoint>(parentBn, properties));
   // TODO(addisu) Remove incrementVersion once DART has been updated to

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -332,6 +332,10 @@ TEST_F(JointFeaturesFixture, JointAttachDetach)
   // the same as it was before they were attached
   fixedJoint->SetTransformFromParent(poseParentChild);
 
+  // The name of the link obtained using the ign-physics API should remain the
+  // same even though AttachFixedJoint renames the associated BodyNode.
+  EXPECT_EQ(bodyName, model2Body->GetName());
+
   for (std::size_t i = 0; i < numSteps; ++i)
   {
     world->Step(output, state, input);
@@ -348,6 +352,10 @@ TEST_F(JointFeaturesFixture, JointAttachDetach)
 
   // now detach joint and expect model2 to start moving again
   fixedJoint->Detach();
+
+  // The name of the link obtained using the ign-physics API should remain the
+  // same even though Detach renames the associated BodyNode.
+  EXPECT_EQ(bodyName, model2Body->GetName());
 
   for (std::size_t i = 0; i < numSteps; ++i)
   {
@@ -410,12 +418,22 @@ TEST_F(JointFeaturesFixture, LinkCountsInJointAttachDetach)
 
   // now detach joint and expect model2 to start moving again
   fixedJoint->Detach();
-  // After detaching we expect each model to have 1 link, but the current
-  // behavior is that there are 2 links in model1 and 0 in model2
-  // EXPECT_EQ(1u, model1->GetLinkCount());
-  // EXPECT_EQ(1u, model2->GetLinkCount());
-  EXPECT_EQ(2u, model1->GetLinkCount());
-  EXPECT_EQ(0u, model2->GetLinkCount());
+  // After detaching we expect each model to have 1 link
+  EXPECT_EQ(1u, model1->GetLinkCount());
+  EXPECT_EQ(1u, model2->GetLinkCount());
+
+  // Test that a model with the same name as a link doesn't cause problems
+  const std::string modelName3{"body"};
+  auto model3 = world->GetModel(modelName3);
+  EXPECT_EQ(1u, model3->GetLinkCount());
+
+  auto model3Body = model3->GetLink(bodyName);
+  auto fixedJoint2 = model3Body->AttachFixedJoint(model2Body);
+  EXPECT_EQ(2u, model2->GetLinkCount());
+  fixedJoint2->Detach();
+  // After detaching we expect each model to have 1 link
+  EXPECT_EQ(1u, model2->GetLinkCount());
+  EXPECT_EQ(1u, model3->GetLinkCount());
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/worlds/joint_across_models.sdf
+++ b/dartsim/worlds/joint_across_models.sdf
@@ -100,6 +100,42 @@
         </visual>
       </link>
     </model>
+    <model name="body">
+      <pose>10 0 3.0 0 0.0 0</pose>
+      <link name="body">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
   </world>
 </sdf>
 


### PR DESCRIPTION
The is was originally opened by @scpeters before the Github migration ([archived PR](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-physics/pull-requests/104)). I have modified it to store the original names of links and using those names when moving BodyNodes between skeletons. 