### PR TITLE
Add tpelib::Shape::GetSize() and tpelib::Model::GetCanonicalLink()

### DIFF
--- a/tpe/lib/src/Model.cc
+++ b/tpe/lib/src/Model.cc
@@ -47,6 +47,14 @@ Entity &Model::AddLink()
 }
 
 //////////////////////////////////////////////////
+Entity &Model::GetCanonicalLink()
+{
+  // return first link as canonical link
+  return *this->GetChildren().begin()->second;
+}
+
+
+//////////////////////////////////////////////////
 void Model::SetLinearVelocity(const math::Vector3d _velocity)
 {
   this->linearVelocity = _velocity;

--- a/tpe/lib/src/Model.hh
+++ b/tpe/lib/src/Model.hh
@@ -47,6 +47,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Model : public Entity
   /// \return Newly created Link
   public: Entity &AddLink();
 
+  /// \brief Get the canonical link of model
+  /// \return Entity the canonical (first) link
   public: Entity &GetCanonicalLink();
 
   /// \brief Set the linear velocity of model

--- a/tpe/lib/src/Model.hh
+++ b/tpe/lib/src/Model.hh
@@ -47,6 +47,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Model : public Entity
   /// \return Newly created Link
   public: Entity &AddLink();
 
+  public: Entity &GetCanonicalLink();
+
   /// \brief Set the linear velocity of model
   /// \param[in] _velocity linear velocity
   public: void SetLinearVelocity(const math::Vector3d _velocity);

--- a/tpe/lib/src/Shape.cc
+++ b/tpe/lib/src/Shape.cc
@@ -85,6 +85,12 @@ void BoxShape::SetSize(const math::Vector3d &_size)
 }
 
 //////////////////////////////////////////////////
+math::Vector3d BoxShape::GetSize()
+{
+  return this->size;
+}
+
+//////////////////////////////////////////////////
 void BoxShape::UpdateBoundingBox()
 {
   math::Vector3d halfSize = this->size * 0.5;

--- a/tpe/lib/src/Shape_TEST.cc
+++ b/tpe/lib/src/Shape_TEST.cc
@@ -37,6 +37,7 @@ TEST(Shape, BoxShape)
 
   math::Vector3d size(1.2, 3.6, 5.8);
   shape.SetSize(size);
+  EXPECT_EQ(size, shape.GetSize());
   math::AxisAlignedBox bbox = shape.GetBoundingBox();
   EXPECT_EQ(math::Vector3d::Zero, bbox.Center());
   EXPECT_EQ(size, bbox.Size());


### PR DESCRIPTION
`tpelib::BoxShape::GetSize()` was declared but not implemented in previous PR and caused windows CI failure in `tpe_plugin` PR

`tpelib::Model::GetCanonicalLink()` assumes the first link of each model is the canonical link, thus enabling ign-gazebo to find the link entity https://github.com/ignitionrobotics/ign-gazebo/blob/2259f027cd3a244f2c841b62c968088eace1b338/src/systems/physics/Physics.cc#L1233 and update world pose accordingly. 

This PR needs to be merged before #32 