### PR TITLE
[Citadel][TPE] Implement collision filtering using collide bitmasks and add CollisionFilterMaskFeature

### DIFF
--- a/tpe/lib/src/Collision.cc
+++ b/tpe/lib/src/Collision.cc
@@ -24,6 +24,9 @@ class ignition::physics::tpelib::CollisionPrivate
 {
   /// \brief Collision's geometry shape
   public: std::shared_ptr<Shape> shape = nullptr;
+
+  /// \brief Collide bitmask
+  public: uint16_t collideBitmask = 0xFF;
 };
 
 using namespace ignition;
@@ -106,4 +109,16 @@ math::AxisAlignedBox Collision::GetBoundingBox(bool /*_force*/) // NOLINT
   if (this->dataPtr->shape)
     return this->dataPtr->shape->GetBoundingBox();
   return math::AxisAlignedBox();
+}
+
+//////////////////////////////////////////////////
+void Collision::SetCollideBitmask(uint16_t _mask)
+{
+  this->dataPtr->collideBitmask = _mask;
+}
+
+//////////////////////////////////////////////////
+uint16_t Collision::GetCollideBitmask() const
+{
+  return this->dataPtr->collideBitmask;
 }

--- a/tpe/lib/src/Collision.cc
+++ b/tpe/lib/src/Collision.cc
@@ -115,6 +115,8 @@ math::AxisAlignedBox Collision::GetBoundingBox(bool /*_force*/) // NOLINT
 void Collision::SetCollideBitmask(uint16_t _mask)
 {
   this->dataPtr->collideBitmask = _mask;
+  if (this->GetParent())
+    this->GetParent()->ChildrenChanged();
 }
 
 //////////////////////////////////////////////////

--- a/tpe/lib/src/Collision.hh
+++ b/tpe/lib/src/Collision.hh
@@ -62,6 +62,13 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Collision : public Entity
   /// \return shape of collision
   public: Shape *GetShape() const;
 
+  /// \brief Set collide bitmask
+  /// \param[in] _mask Bitmask to set
+  public: void SetCollideBitmask(uint16_t _mask);
+
+  // Documentation Inherited
+  public: uint16_t GetCollideBitmask() const override;
+
   // Documentation inherited
   public: math::AxisAlignedBox GetBoundingBox(bool _force) override;
 

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <unordered_map>
+
 #include "CollisionDetector.hh"
 #include "Utils.hh"
 
@@ -31,23 +33,15 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
   // contacts to be filled and returned
   std::vector<Contact> contacts;
 
-  // cache of collide bitmasks
-  std::map<std::size_t, uint16_t> collideBitmasks;
-
   // cache of axis aligned box in world frame
-  std::map<std::size_t, math::AxisAlignedBox> worldAabb;
+  std::unordered_map<std::size_t, math::AxisAlignedBox> worldAabb;
 
   for (auto it = _entities.begin(); it != _entities.end(); ++it)
   {
     std::shared_ptr<Entity> e1 = it->second;
 
     // Get collide bitmask for enitty 1
-    uint16_t cb1 = 0xFF;
-    auto cb1It = collideBitmasks.find(e1->GetId());
-    if (cb1It == collideBitmasks.end())
-      collideBitmasks[e1->GetId()] = e1->GetCollideBitmask();
-    else
-      cb1 = cb1It->second;
+    uint16_t cb1 = e1->GetCollideBitmask();
 
     // Get world axis aligned box for entity 1
     math::AxisAlignedBox wb1;
@@ -71,12 +65,7 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
       std::shared_ptr<Entity> e2 = it2->second;
 
       // Get collide bitmask for entity 2
-      uint16_t cb2 = 0xFF;
-      auto cb2It = collideBitmasks.find(e2->GetId());
-      if (cb2It == collideBitmasks.end())
-        collideBitmasks[e2->GetId()] = e2->GetCollideBitmask();
-      else
-        cb2 = cb2It->second;
+      uint16_t cb2 = e2->GetCollideBitmask();
 
       // collision filtering using collide bitmask
       if ((cb1 & cb2) == 0)

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -31,14 +31,26 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
   // contacts to be filled and returned
   std::vector<Contact> contacts;
 
+  // cache of collide bitmasks
+  std::map<std::size_t, uint16_t> collideBitmasks;
+
   // cache of axis aligned box in world frame
   std::map<std::size_t, math::AxisAlignedBox> worldAabb;
 
   for (auto it = _entities.begin(); it != _entities.end(); ++it)
   {
+    std::shared_ptr<Entity> e1 = it->second;
+
+    // Get collide bitmask for enitty 1
+    uint16_t cb1 = 0xFF;
+    auto cb1It = collideBitmasks.find(e1->GetId());
+    if (cb1It == collideBitmasks.end())
+      collideBitmasks[e1->GetId()] = e1->GetCollideBitmask();
+    else
+      cb1 = cb1It->second;
+
     // Get world axis aligned box for entity 1
     math::AxisAlignedBox wb1;
-    std::shared_ptr<Entity> e1 = it->second;
     auto wb1It = worldAabb.find(e1->GetId());
     if (wb1It == worldAabb.end())
     {
@@ -56,9 +68,22 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
 
     for (auto it2 = std::next(it, 1); it2 != _entities.end(); ++it2)
     {
+      std::shared_ptr<Entity> e2 = it2->second;
+
+      // Get collid bitmask for entity 2
+      uint16_t cb2 = 0xFF;
+      auto cb2It = collideBitmasks.find(e2->GetId());
+      if (cb2It == collideBitmasks.end())
+        collideBitmasks[e2->GetId()] = e2->GetCollideBitmask();
+      else
+        cb2 = cb2It->second;
+
+      // collision filtering using collide bitmask
+      if ((cb1 & cb2) == 0)
+        continue;
+
       // Get world axis aligned box for entity 2
       math::AxisAlignedBox wb2;
-      std::shared_ptr<Entity> e2 = it2->second;
       auto wb2It = worldAabb.find(e2->GetId());
       if (wb2It == worldAabb.end())
       {

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -70,7 +70,7 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
     {
       std::shared_ptr<Entity> e2 = it2->second;
 
-      // Get collid bitmask for entity 2
+      // Get collide bitmask for entity 2
       uint16_t cb2 = 0xFF;
       auto cb2It = collideBitmasks.find(e2->GetId());
       if (cb2It == collideBitmasks.end())

--- a/tpe/lib/src/Collision_TEST.cc
+++ b/tpe/lib/src/Collision_TEST.cc
@@ -37,6 +37,10 @@ TEST(Collision, BasicAPI)
   collision.SetPose(math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3));
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0.1, 0.2, 0.3), collision.GetPose());
 
+  EXPECT_EQ(0xFF, collision.GetCollideBitmask());
+  collision.SetCollideBitmask(0x03);
+  EXPECT_EQ(0x03, collision.GetCollideBitmask());
+
   Collision collision2;
   EXPECT_NE(collision.GetId(), collision2.GetId());
 }

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -241,6 +241,17 @@ void Entity::UpdateBoundingBox(bool _force)
 }
 
 //////////////////////////////////////////////////
+uint16_t Entity::GetCollideBitmask() const
+{
+  uint16_t mask = 0u;
+  for (auto &it : this->dataPtr->children)
+  {
+    mask |= it.second->GetCollideBitmask();
+  }
+  return mask;
+}
+
+//////////////////////////////////////////////////
 std::map<std::size_t, std::shared_ptr<Entity>> &Entity::GetChildren() const
 {
   return this->dataPtr->children;

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -285,7 +285,7 @@ std::size_t Entity::GetNextId()
 void Entity::ChildrenChanged()
 {
   this->dataPtr->bboxDirty = true;
-  this->dataPtr->collideBitmaskDirty= true;
+  this->dataPtr->collideBitmaskDirty = true;
 
   if (this->dataPtr->parent)
     this->dataPtr->parent->ChildrenChanged();

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -135,6 +135,21 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   /// \return Collision's collide bitmask
   public: virtual uint16_t GetCollideBitmask() const;
 
+  /// \internal
+  /// \brief Set the parent of this entity.
+  /// \param[in] _parent Parent to set to
+  public: void SetParent(Entity *_parent);
+
+  /// \internal
+  /// \brief Get the parent of this entity.
+  /// \return Parent of this entity
+  public: Entity *GetParent() const;
+
+  /// \internal
+  /// \brief Mark that the children of the entity has changed, e.g. a child
+  /// entity is added or removed, or child entity properties changed.
+  public: void ChildrenChanged();
+
   /// \brief Get number of children
   /// \return Map of child id's to child entities
   protected: std::map<std::size_t, std::shared_ptr<Entity>> &GetChildren()

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -131,6 +131,10 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   /// \return Entity bounding box
   public: virtual math::AxisAlignedBox GetBoundingBox(bool _force = false);
 
+  /// \brief Get collide bitmask
+  /// \return Collision's collide bitmask
+  public: virtual uint16_t GetCollideBitmask() const;
+
   /// \brief Get number of children
   /// \return Map of child id's to child entities
   protected: std::map<std::size_t, std::shared_ptr<Entity>> &GetChildren()

--- a/tpe/lib/src/Link.cc
+++ b/tpe/lib/src/Link.cc
@@ -38,5 +38,7 @@ Entity &Link::AddCollision()
   std::size_t collisionId = Entity::GetNextId();
   const auto[it, success] = this->GetChildren().insert(
     {collisionId, std::make_shared<Collision>(collisionId)});
+  it->second->SetParent(this);
+  this->ChildrenChanged();
   return *it->second.get();
 }

--- a/tpe/lib/src/Model.cc
+++ b/tpe/lib/src/Model.cc
@@ -43,6 +43,9 @@ Entity &Model::AddLink()
   std::size_t linkId = Entity::GetNextId();
   const auto[it, success]  = this->GetChildren().insert(
       {linkId, std::make_shared<Link>(linkId)});
+
+  it->second->SetParent(this);
+  this->ChildrenChanged();
   return *it->second.get();
 }
 

--- a/tpe/lib/src/Model_TEST.cc
+++ b/tpe/lib/src/Model_TEST.cc
@@ -160,3 +160,42 @@ TEST(Model, BoundingBox)
       math::Vector3d(-2, -2, -2.5), math::Vector3d(2, 3, 3));
   EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox(true));
 }
+
+/////////////////////////////////////////////////
+TEST(Model, CollideBitmask)
+{
+  Model model;
+  EXPECT_EQ(0x00, model.GetCollideBitmask());
+
+  // add link and verify bitmask is still empty
+  Entity &linkEnt = model.AddLink();
+  EXPECT_EQ(0x00, linkEnt.GetCollideBitmask());
+  EXPECT_EQ(0x00, model.GetCollideBitmask());
+
+  // add a collision and verify the model has the same collision bitmask
+  Link *link = static_cast<Link *>(&linkEnt);
+  Entity &collisionEnt = link->AddCollision();
+  Collision *collision = static_cast<Collision *>(&collisionEnt);
+  collision->SetCollideBitmask(0x01);
+  EXPECT_EQ(0x01, collision->GetCollideBitmask());
+  EXPECT_EQ(0x01, linkEnt.GetCollideBitmask());
+  EXPECT_EQ(0x01, model.GetCollideBitmask());
+
+  // add another collision and verify bitmasks are bitwise OR'd.
+  Entity &collisionEnt2 = link->AddCollision();
+  Collision *collision2 = static_cast<Collision *>(&collisionEnt2);
+  collision2->SetCollideBitmask(0x04);
+  EXPECT_EQ(0x04, collision2->GetCollideBitmask());
+  EXPECT_EQ(0x05, linkEnt.GetCollideBitmask());
+  EXPECT_EQ(0x05, model.GetCollideBitmask());
+
+  // add another link with collision and verify
+  Entity &linkEnt2 = model.AddLink();
+  Link *link2 = static_cast<Link *>(&linkEnt2);
+  Entity &collisionEnt3 = link2->AddCollision();
+  Collision *collision3 = static_cast<Collision *>(&collisionEnt3);
+  collision3->SetCollideBitmask(0x09);
+  EXPECT_EQ(0x09, collision3->GetCollideBitmask());
+  EXPECT_EQ(0x09, linkEnt2.GetCollideBitmask());
+  EXPECT_EQ(0x0D, model.GetCollideBitmask());
+}

--- a/tpe/lib/src/Model_TEST.cc
+++ b/tpe/lib/src/Model_TEST.cc
@@ -133,11 +133,11 @@ TEST(Model, BoundingBox)
 
   math::AxisAlignedBox expectedBoxLinkFrame(
       math::Vector3d(-2, -2, -2), math::Vector3d(2, 2, 2));
-  EXPECT_EQ(expectedBoxLinkFrame, linkEnt.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxLinkFrame, linkEnt.GetBoundingBox());
 
   math::AxisAlignedBox expectedBoxModelFrame(
       math::Vector3d(-2, -2, -1), math::Vector3d(2, 2, 3));
-  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox());
 
   // add another link with box collision shape
   Entity &linkEnt2 = model.AddLink();
@@ -154,11 +154,11 @@ TEST(Model, BoundingBox)
 
   expectedBoxLinkFrame = math::AxisAlignedBox(
       math::Vector3d(-1.5, -2, -2.5), math::Vector3d(1.5, 2, 2.5));
-  EXPECT_EQ(expectedBoxLinkFrame, linkEnt2.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxLinkFrame, linkEnt2.GetBoundingBox());
 
   expectedBoxModelFrame = math::AxisAlignedBox(
       math::Vector3d(-2, -2, -2.5), math::Vector3d(2, 3, 3));
-  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox());
 }
 
 /////////////////////////////////////////////////

--- a/tpe/plugin/src/EntityManagementFeatures.cc
+++ b/tpe/plugin/src/EntityManagementFeatures.cc
@@ -425,11 +425,6 @@ Identity EntityManagementFeatures::ConstructEmptyLink(
 void EntityManagementFeatures::SetCollisionFilterMask(
     const Identity &_shapeID, const uint16_t _mask)
 {
-/*  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
-  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
-  const auto filterPtr = GetFilterPtr(this, worldID);
-  filterPtr->SetIgnoredCollision(shapeNode, _mask);
-*/
   auto collision =
       this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
   collision->SetCollideBitmask(_mask);
@@ -439,12 +434,6 @@ void EntityManagementFeatures::SetCollisionFilterMask(
 uint16_t EntityManagementFeatures::GetCollisionFilterMask(
     const Identity &_shapeID) const
 {
-/*
-  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
-  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
-  const auto filterPtr = GetFilterPtr(this, worldID);
-  return filterPtr->GetIgnoredCollision(shapeNode);
-*/
   const auto collision =
       this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
   return collision->GetCollideBitmask();
@@ -454,15 +443,8 @@ uint16_t EntityManagementFeatures::GetCollisionFilterMask(
 void EntityManagementFeatures::RemoveCollisionFilterMask(
     const Identity &_shapeID)
 {
-/*
-  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
-  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
-  const auto filterPtr = GetFilterPtr(this, worldID);
-  filterPtr->RemoveIgnoredCollision(shapeNode);
-*/
   auto collision =
       this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
   // remove = reset to default bitmask
   collision->SetCollideBitmask(0xFF);
 }
-

--- a/tpe/plugin/src/EntityManagementFeatures.cc
+++ b/tpe/plugin/src/EntityManagementFeatures.cc
@@ -420,3 +420,49 @@ Identity EntityManagementFeatures::ConstructEmptyLink(
   }
   return this->GenerateInvalidId();
 }
+
+/////////////////////////////////////////////////
+void EntityManagementFeatures::SetCollisionFilterMask(
+    const Identity &_shapeID, const uint16_t _mask)
+{
+/*  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
+  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
+  const auto filterPtr = GetFilterPtr(this, worldID);
+  filterPtr->SetIgnoredCollision(shapeNode, _mask);
+*/
+  auto collision =
+      this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
+  collision->SetCollideBitmask(_mask);
+}
+
+/////////////////////////////////////////////////
+uint16_t EntityManagementFeatures::GetCollisionFilterMask(
+    const Identity &_shapeID) const
+{
+/*
+  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
+  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
+  const auto filterPtr = GetFilterPtr(this, worldID);
+  return filterPtr->GetIgnoredCollision(shapeNode);
+*/
+  const auto collision =
+      this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
+  return collision->GetCollideBitmask();
+}
+
+/////////////////////////////////////////////////
+void EntityManagementFeatures::RemoveCollisionFilterMask(
+    const Identity &_shapeID)
+{
+/*
+  const auto shapeNode = this->ReferenceInterface<ShapeInfo>(_shapeID)->node;
+  const std::size_t worldID = GetWorldOfShapeNode(this, shapeNode);
+  const auto filterPtr = GetFilterPtr(this, worldID);
+  filterPtr->RemoveIgnoredCollision(shapeNode);
+*/
+  auto collision =
+      this->ReferenceInterface<CollisionInfo>(_shapeID)->collision;
+  // remove = reset to default bitmask
+  collision->SetCollideBitmask(0xFF);
+}
+

--- a/tpe/plugin/src/EntityManagementFeatures.hh
+++ b/tpe/plugin/src/EntityManagementFeatures.hh
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <ignition/physics/ConstructEmpty.hh>
+#include <ignition/physics/Shape.hh>
 #include <ignition/physics/GetEntities.hh>
 #include <ignition/physics/RemoveEntities.hh>
 #include <ignition/physics/Implements.hh>
@@ -40,7 +41,8 @@ struct EntityManagementFeatureList : FeatureList<
   RemoveEntities,
   ConstructEmptyWorldFeature,
   ConstructEmptyModelFeature,
-  ConstructEmptyLinkFeature
+  ConstructEmptyLinkFeature,
+  CollisionFilterMaskFeature
 > { };
 
 class EntityManagementFeatures :
@@ -135,6 +137,15 @@ class EntityManagementFeatures :
 
   public: Identity ConstructEmptyLink(
     const Identity &_modelID, const std::string &_name) override;
+
+  // ----- Manage collision filter masks -----
+  public: void SetCollisionFilterMask(
+      const Identity &_shapeID, const uint16_t _mask) override;
+
+  public: uint16_t GetCollisionFilterMask(
+      const Identity &_shapeID) const override;
+
+  public: void RemoveCollisionFilterMask(const Identity &_shapeID) override;
 };
 
 }

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -24,9 +24,9 @@
 #include <sdf/World.hh>
 #include <ignition/common/Console.hh>
 
-using namespace ignition;
-using namespace physics;
-using namespace tpeplugin;
+namespace ignition {
+namespace physics {
+namespace tpeplugin {
 
 /////////////////////////////////////////////////
 Identity SDFFeatures::ConstructSdfWorld(
@@ -192,4 +192,8 @@ Identity SDFFeatures::ConstructSdfCollision(
   }
 
   return collisionIdentity;
+}
+
+}
+}
 }

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -168,5 +168,27 @@ Identity SDFFeatures::ConstructSdfCollision(
   // and passed in as argument as there is no logic for searching resources
   // in ign-physics
   const auto collisionIdentity = this->AddCollision(link->GetId(), *collision);
+
+  // set collide bitmask
+  uint16_t collideBitmask = 0xFF;
+  if (_sdfCollision.Element())
+  {
+    // TODO(anyone) add category_bitmask as well
+    auto elem = _sdfCollision.Element();
+    if (elem->HasElement("surface"))
+    {
+      elem = elem->GetElement("surface");
+      if (elem->HasElement("contact"))
+      {
+        elem = elem->GetElement("contact");
+        if (elem->HasElement("collide_bitmask"))
+        {
+          collideBitmask = elem->Get<unsigned int>("collide_bitmask");
+          this->SetCollisionFilterMask(collisionIdentity, collideBitmask);
+        }
+      }
+    }
+  }
+
   return collisionIdentity;
 }

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -17,6 +17,7 @@
 
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
+#include <sdf/Element.hh>
 #include <sdf/Sphere.hh>
 #include <sdf/Geometry.hh>
 #include <ignition/common/Console.hh>

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -17,7 +17,6 @@
 
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
-#include <sdf/Element.hh>
 #include <sdf/Sphere.hh>
 #include <sdf/Geometry.hh>
 #include <ignition/common/Console.hh>
@@ -184,7 +183,7 @@ Identity SDFFeatures::ConstructSdfCollision(
         elem = elem->GetElement("contact");
         if (elem->HasElement("collide_bitmask"))
         {
-          collideBitmask = elem->Get<unsigned int>("collide_bitmask");
+          collideBitmask = elem->Get<int>("collide_bitmask");
           this->SetCollisionFilterMask(collisionIdentity, collideBitmask);
         }
       }

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -15,13 +15,14 @@
  *
 */
 
+#include "SDFFeatures.hh"
+
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Sphere.hh>
 #include <sdf/Geometry.hh>
+#include <sdf/World.hh>
 #include <ignition/common/Console.hh>
-
-#include "SDFFeatures.hh"
 
 using namespace ignition;
 using namespace physics;
@@ -183,7 +184,7 @@ Identity SDFFeatures::ConstructSdfCollision(
         elem = elem->GetElement("contact");
         if (elem->HasElement("collide_bitmask"))
         {
-          collideBitmask = elem->Get<int>("collide_bitmask");
+          collideBitmask = elem->Get<unsigned int>("collide_bitmask");
           this->SetCollisionFilterMask(collisionIdentity, collideBitmask);
         }
       }

--- a/tpe/plugin/src/SDFFeatures.hh
+++ b/tpe/plugin/src/SDFFeatures.hh
@@ -18,10 +18,6 @@
 #ifndef IGNITION_PHYSICS_TPE_PLUGIN_SRC_SDFFEATURES_HH_
 #define IGNITION_PHYSICS_TPE_PLUGIN_SRC_SDFFEATURES_HH_
 
-#include <sdf/Collision.hh>
-#include <sdf/Link.hh>
-#include <sdf/Joint.hh>
-
 #include <ignition/physics/sdf/ConstructCollision.hh>
 #include <ignition/physics/sdf/ConstructLink.hh>
 #include <ignition/physics/sdf/ConstructModel.hh>

--- a/tpe/plugin/worlds/shapes_bitmask.sdf
+++ b/tpe/plugin/worlds/shapes_bitmask.sdf
@@ -1,0 +1,154 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="shapes_bitmask">
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box_base">
+      <pose>0 0 10.0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <collide_bitmask>0x01</collide_bitmask>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box_filtered">
+      <pose>0 0.75 10.0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <collide_bitmask>0x02</collide_bitmask>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0 1 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box_colliding">
+      <pose>0 -0.75 10.0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <collide_bitmask>0x03</collide_bitmask>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0 1</ambient>
+            <diffuse>1 1 0 1</diffuse>
+            <specular>1 1 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Added collide bitmask to Collisions in tpelib for doing collision filtering. 

Since collision detection in TPE is done between models (not collisions), I also added a function to Entity to get a single combined (bitwise OR'd) collide bitmask from all child collisions. e.g. if one collision within model A can collide with any one of the collisions in model B then the two models should collide. 

Also added the CollisionFilterMaskFeature similar to the way it was done for dart in this [pull reqeuest](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-physics/pull-requests/116/page/1)