### PR TITLE
[Citadel][TPE] Cache Entity data

### DIFF
--- a/tpe/lib/src/Collision.cc
+++ b/tpe/lib/src/Collision.cc
@@ -115,6 +115,8 @@ math::AxisAlignedBox Collision::GetBoundingBox(bool /*_force*/) // NOLINT
 void Collision::SetCollideBitmask(uint16_t _mask)
 {
   this->dataPtr->collideBitmask = _mask;
+  if (this->GetParent())
+    this->GetParent()->ChildrenChanged();
 }
 
 //////////////////////////////////////////////////

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -135,6 +135,21 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   /// \return Collision's collide bitmask
   public: virtual uint16_t GetCollideBitmask() const;
 
+  /// \internal
+  /// \brief Set the parent of this entity.
+  /// \param[in] _parent Parent to set to
+  public: void SetParent(Entity *_parent);
+
+  /// \internal
+  /// \brief Get the parent of this entity.
+  /// \return Parent of this entity
+  public: Entity *GetParent() const;
+
+  /// \internal
+  /// \brief Mark that the children of the entity has changed, e.g. a child
+  /// entity is added or removed, or child entity properties changed.
+  public: void ChildrenChanged();
+
   /// \brief Get number of children
   /// \return Map of child id's to child entities
   protected: std::map<std::size_t, std::shared_ptr<Entity>> &GetChildren()

--- a/tpe/lib/src/Link.cc
+++ b/tpe/lib/src/Link.cc
@@ -38,5 +38,7 @@ Entity &Link::AddCollision()
   std::size_t collisionId = Entity::GetNextId();
   const auto[it, success] = this->GetChildren().insert(
     {collisionId, std::make_shared<Collision>(collisionId)});
+  it->second->SetParent(this);
+  this->ChildrenChanged();
   return *it->second.get();
 }

--- a/tpe/lib/src/Model.cc
+++ b/tpe/lib/src/Model.cc
@@ -43,6 +43,9 @@ Entity &Model::AddLink()
   std::size_t linkId = Entity::GetNextId();
   const auto[it, success]  = this->GetChildren().insert(
       {linkId, std::make_shared<Link>(linkId)});
+
+  it->second->SetParent(this);
+  this->ChildrenChanged();
   return *it->second.get();
 }
 

--- a/tpe/lib/src/Model_TEST.cc
+++ b/tpe/lib/src/Model_TEST.cc
@@ -133,11 +133,11 @@ TEST(Model, BoundingBox)
 
   math::AxisAlignedBox expectedBoxLinkFrame(
       math::Vector3d(-2, -2, -2), math::Vector3d(2, 2, 2));
-  EXPECT_EQ(expectedBoxLinkFrame, linkEnt.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxLinkFrame, linkEnt.GetBoundingBox());
 
   math::AxisAlignedBox expectedBoxModelFrame(
       math::Vector3d(-2, -2, -1), math::Vector3d(2, 2, 3));
-  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox());
 
   // add another link with box collision shape
   Entity &linkEnt2 = model.AddLink();
@@ -154,11 +154,11 @@ TEST(Model, BoundingBox)
 
   expectedBoxLinkFrame = math::AxisAlignedBox(
       math::Vector3d(-1.5, -2, -2.5), math::Vector3d(1.5, 2, 2.5));
-  EXPECT_EQ(expectedBoxLinkFrame, linkEnt2.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxLinkFrame, linkEnt2.GetBoundingBox());
 
   expectedBoxModelFrame = math::AxisAlignedBox(
       math::Vector3d(-2, -2, -2.5), math::Vector3d(2, 3, 3));
-  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox(true));
+  EXPECT_EQ(expectedBoxModelFrame, model.GetBoundingBox());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Added flags to keep track of entity changes so that we can return cached data like collide bitmasks and bounding box if no changes are detected.

While making these changes, I noticed there was already a flag to keep track of bounding box changes (`bboxDirty`) but it was never set to true so bounding boxes were never recomputed.

I added some logic and public functions to to help propagate these flags up the tree (`Set|GetParent`, `ChildrenChanged`). Not ideal so feedback welcome. 


Signed-off-by: Ian Chen <ichen@osrfoundation.org>