### PR TITLE
Enforce joint effort limit in dartsim-plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Physics 1.x.x (20XX-XX-XX)
 
+1. Enforce joint effort limit in dartsim-plugin
+    * [Pull request 74](https://github.com/ignitionrobotics/ign-physics/pull/74)
+
 ### Ignition Physics 1.8.0 (2020-05-08)
 
 1. Restore detached BodyNodes to original skeleton

--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -67,6 +67,8 @@ foreach(test ${tests})
     "TEST_WORLD_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/worlds/\""
     "IGNITION_PHYSICS_RESOURCE_DIR=\"${IGNITION_PHYSICS_RESOURCE_DIR}\"")
 
+  # Helps when we want to build a single test after making changes to dartsim_plugin
+  add_dependencies(${test} ${dartsim_plugin})
 endforeach()
 
 foreach(test UNIT_FindFeatures_TEST UNIT_RequestFeatures_TEST)

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -89,7 +89,12 @@ void JointFeatures::SetJointAcceleration(
 void JointFeatures::SetJointForce(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
-  this->ReferenceInterface<JointInfo>(_id)->joint->setForce(_dof, _value);
+  auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+  if (joint->getActuatorType() != dart::dynamics::Joint::FORCE)
+  {
+    joint->setActuatorType(dart::dynamics::Joint::FORCE);
+  }
+  this->ReferenceInterface<JointInfo>(_id)->joint->setCommand(_dof, _value);
 }
 
 /////////////////////////////////////////////////

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -28,6 +28,7 @@
 
 #include <ignition/plugin/Loader.hh>
 
+#include <ignition/physics/GetEntities.hh>
 #include <ignition/physics/Joint.hh>
 #include <ignition/physics/RequestEngine.hh>
 
@@ -42,6 +43,7 @@
 #include <sdf/World.hh>
 
 using TestFeatureList = ignition::physics::FeatureList<
+  ignition::physics::GetEntities,
   ignition::physics::GetBasicJointState,
   ignition::physics::SetBasicJointState,
   ignition::physics::dartsim::RetrieveWorld,
@@ -187,24 +189,27 @@ TEST(SDFFeatures_TEST, CheckJointLimitEnforcement)
   dart::simulation::WorldPtr dartWorld = world.GetDartsimWorld();
   ASSERT_NE(nullptr, dartWorld);
 
+  const auto model = world.GetModel("joint_limit_test");
   const dart::dynamics::SkeletonPtr skeleton =
       dartWorld->getSkeleton("joint_limit_test");
   ASSERT_NE(nullptr, skeleton);
   auto * const joint = dynamic_cast<dart::dynamics::RevoluteJoint *>(
       skeleton->getJoint(1));
+  auto jointPhys = model->GetJoint(1);
 
   ASSERT_NE(nullptr, joint);
   // the joint starts at 0. Apply force in either direction and check the limits
   // are enforced
-  auto verify = [&dartWorld](dart::dynamics::DegreeOfFreedom * const dof,
-                             const double force, const double tol)
+  auto verify = [&](std::size_t index, const double force, const double tol)
   {
     dartWorld->reset();
-    dof->setForce(force);
+    dart::dynamics::DegreeOfFreedom * const dof = joint->getDof(index);
+    jointPhys->SetForce(index, force);
     for (std::size_t i = 0; i < 1000; ++i)
     {
       dartWorld->step();
     }
+    jointPhys->SetForce(index, force);
     EXPECT_LE(dof->getPositionLowerLimit() - tol, dof->getPosition());
     EXPECT_LE(dof->getForceLowerLimit() - tol, dof->getForce());
     EXPECT_LE(dof->getVelocityLowerLimit() - tol, dof->getVelocity());
@@ -214,8 +219,8 @@ TEST(SDFFeatures_TEST, CheckJointLimitEnforcement)
     EXPECT_GE(dof->getVelocityUpperLimit() + tol, dof->getVelocity());
   };
 
-  verify(joint->getDof(0), -1000, 2e-3);
-  verify(joint->getDof(0), 1000, 2e-3);
+  verify(0, -1000, 2e-3);
+  verify(0, 1000, 2e-3);
 }
 
 // Create Model with parent and child links. If a link is not set, the joint


### PR DESCRIPTION
This enforces joint limits by using the Joint::FORCE actuator and calling `Joint::setCommand` instead of `Joint::setForce`. https://github.com/ignitionrobotics/ign-physics/commit/f9ff53adc07695644260169ec50f02f339b1ca68 fixes a joint effort limit test by making sure a joint force is set after `World::step` is called because DART clears joint forces after `World::step`. This makes the test fail in that commit. The commit also uses the ignition-physics Feature to set joint forces so that the whole API is tested. https://github.com/ignitionrobotics/ign-physics/commit/c2685feccc8fcb9443761337ed53a07f0db9a194 fixes the failing test.

Closes https://github.com/ignitionrobotics/ign-gazebo/issues/226
