### PR TITLE
Fix copying SpecifyData objects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Physics 2.x.x (20XX-XX-XX)
 
+1. Fix copying of SpecifyData objects
+    * [Pull Request 77](https://github.com/ignitionrobotics/ign-physics/pull/77)
+
 ### Ignition Physics 2.1.0 (2020-05-07)
 
 1. Add RequestFeatures API for casting the features of an entity to a new feature set when possible.

--- a/include/ignition/physics/SpecifyData.hh
+++ b/include/ignition/physics/SpecifyData.hh
@@ -48,6 +48,17 @@ namespace ignition
       /// \brief Default constructor
       public: ExpectData();
 
+      /// \brief Copy constructor.
+      public: ExpectData(const ExpectData &_other);
+
+      // /// \brief Copy assignment operator
+      public: ExpectData<Expected>& operator=(const ExpectData &_other);
+
+      /// TODO(anyone) Implement move constructor and assignment operator. Due
+      /// to the multiple inheritence used to implement SpcifyData, care must be
+      /// taken when implementing move constructs to avoid calling a move
+      /// constructor on a moved-from object.
+
       /// \brief Virtual destructor
       public: virtual ~ExpectData() = default;
 

--- a/include/ignition/physics/SpecifyData.hh
+++ b/include/ignition/physics/SpecifyData.hh
@@ -49,10 +49,13 @@ namespace ignition
       public: ExpectData();
 
       /// \brief Copy constructor.
+      /// The copy constructor of the base class, CompositeData, is called
+      /// before this copy constructor and it does the actual copying of the
+      /// data contained in the MapData object of `_other`. Thus, this copy
+      /// constructor simply calls the default constructor to initialize the
+      /// MapData iterator of this object to point the appropriate iterator in
+      /// the newly copied MapData.
       public: ExpectData(const ExpectData &_other);
-
-      // /// \brief Copy assignment operator
-      public: ExpectData<Expected>& operator=(const ExpectData &_other);
 
       /// TODO(anyone) Implement move constructor and assignment operator. Due
       /// to the multiple inheritence used to implement SpcifyData, care must be

--- a/include/ignition/physics/detail/PrivateSpecifyData.hh
+++ b/include/ignition/physics/detail/PrivateSpecifyData.hh
@@ -386,6 +386,22 @@ namespace ignition
           // Do nothing
         }
 
+        /// \brief Copy constructor.
+        /// Explcitly defaulted for clarity.
+        private: PrivateExpectData(const PrivateExpectData&) = default;
+
+        /// \brief Copy assignment operator.
+        /// We need to specify a copy constructor because the compiler will not
+        /// generate one for us. This is because the generated constructor would
+        /// try to copy expectedIterator and fail because it's a const. Since
+        /// expectedIterator is already initialized when the copy assignment
+        /// operator is used we do nothing here.
+        private: PrivateExpectData<Expected> &operator=(
+            const PrivateExpectData<Expected> &)
+        {
+          return *this;
+        }
+
         public: const CompositeData::MapOfData::iterator expectedIterator;
       };
 

--- a/include/ignition/physics/detail/SpecifyData.hh
+++ b/include/ignition/physics/detail/SpecifyData.hh
@@ -41,6 +41,23 @@ namespace ignition
 
     /////////////////////////////////////////////////
     template <typename Expected>
+    ExpectData<Expected>::ExpectData(const ExpectData<Expected> &_other)
+        : ExpectData()
+    {
+      this->Copy(_other);
+    }
+
+    /////////////////////////////////////////////////
+    template <typename Expected>
+    ExpectData<Expected> &ExpectData<Expected>::operator=(
+        const ExpectData<Expected> &_other)
+    {
+      this->Copy(_other);
+      return *this;
+    }
+
+    /////////////////////////////////////////////////
+    template <typename Expected>
     template <typename Data>
     Data &ExpectData<Expected>::Get()
     {

--- a/include/ignition/physics/detail/SpecifyData.hh
+++ b/include/ignition/physics/detail/SpecifyData.hh
@@ -41,19 +41,10 @@ namespace ignition
 
     /////////////////////////////////////////////////
     template <typename Expected>
-    ExpectData<Expected>::ExpectData(const ExpectData<Expected> &_other)
+    ExpectData<Expected>::ExpectData(const ExpectData<Expected> &)
         : ExpectData()
     {
-      this->Copy(_other);
-    }
-
-    /////////////////////////////////////////////////
-    template <typename Expected>
-    ExpectData<Expected> &ExpectData<Expected>::operator=(
-        const ExpectData<Expected> &_other)
-    {
-      this->Copy(_other);
-      return *this;
+      // Do nothing
     }
 
     /////////////////////////////////////////////////

--- a/src/CompositeData.cc
+++ b/src/CompositeData.cc
@@ -195,7 +195,10 @@ namespace ignition
           // should just add each remaining entry from sender. We don't have to
           // worry about conflicts, because this CompositeData cannot already
           // have any of these types.
-          CreateDataFnc(_toMap, sender, _mergeRequirements, _numEntries);
+          if (sender->second.data)
+          {
+            CreateDataFnc(_toMap, sender, _mergeRequirements, _numEntries);
+          }
 
           ++sender;
         }

--- a/src/SpecifyData_TEST.cc
+++ b/src/SpecifyData_TEST.cc
@@ -673,6 +673,16 @@ TEST(SpecifyData, Copy)
     data.Get<StringData>().myString = "new_string";
     EXPECT_EQ("old_string", copyCtor.Get<StringData>().myString);
   }
+
+  {
+    RequireStringBoolChar data;
+    data.Get<StringData>().myString = "old_string";
+    EXPECT_EQ("old_string", data.Get<StringData>().myString);
+
+    RequireStringBoolChar opEqData;
+    opEqData = data;
+    EXPECT_EQ("old_string", opEqData.Get<StringData>().myString);
+  }
 }
 
 /////////////////////////////////////////////////
@@ -683,7 +693,7 @@ TEST(SpecifyData, Move)
     data.Get<StringData>().myString = "old_string";
     EXPECT_EQ("old_string", data.Get<StringData>().myString);
 
-    // TODO(anyone) This is actually doing a copy right now
+    // TODO (anyone) This is actually doing a copy right now
     RequireStringBoolChar moveCtor(std::move(data));
     EXPECT_EQ("old_string", moveCtor.Get<StringData>().myString);
   }
@@ -692,6 +702,10 @@ TEST(SpecifyData, Move)
     RequireStringBoolChar data;
     data.Get<StringData>().myString = "old_string";
     EXPECT_EQ("old_string", data.Get<StringData>().myString);
+
+    RequireStringBoolChar opEqData;
+    opEqData = std::move(data);
+    EXPECT_EQ("old_string", opEqData.Get<StringData>().myString);
   }
 }
 

--- a/src/SpecifyData_TEST.cc
+++ b/src/SpecifyData_TEST.cc
@@ -693,7 +693,7 @@ TEST(SpecifyData, Move)
     data.Get<StringData>().myString = "old_string";
     EXPECT_EQ("old_string", data.Get<StringData>().myString);
 
-    // TODO (anyone) This is actually doing a copy right now
+    // TODO(anyone) This is actually doing a copy right now
     RequireStringBoolChar moveCtor(std::move(data));
     EXPECT_EQ("old_string", moveCtor.Get<StringData>().myString);
   }

--- a/src/SpecifyData_TEST.cc
+++ b/src/SpecifyData_TEST.cc
@@ -659,6 +659,43 @@ TEST(SpecifyData, OtherDataTypes)
 }
 
 /////////////////////////////////////////////////
+TEST(SpecifyData, Copy)
+{
+  {
+    RequireStringBoolChar data;
+    data.Get<StringData>().myString = "old_string";
+    EXPECT_EQ("old_string", data.Get<StringData>().myString);
+
+    RequireStringBoolChar copyCtor(data);
+    EXPECT_EQ("old_string", copyCtor.Get<StringData>().myString);
+
+    // Modify the original and check that the copy is not affected
+    data.Get<StringData>().myString = "new_string";
+    EXPECT_EQ("old_string", copyCtor.Get<StringData>().myString);
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(SpecifyData, Move)
+{
+  {
+    RequireStringBoolChar data;
+    data.Get<StringData>().myString = "old_string";
+    EXPECT_EQ("old_string", data.Get<StringData>().myString);
+
+    // TODO(anyone) This is actually doing a copy right now
+    RequireStringBoolChar moveCtor(std::move(data));
+    EXPECT_EQ("old_string", moveCtor.Get<StringData>().myString);
+  }
+
+  {
+    RequireStringBoolChar data;
+    data.Get<StringData>().myString = "old_string";
+    EXPECT_EQ("old_string", data.Get<StringData>().myString);
+  }
+}
+
+/////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This fixes a crash when copying `SpecifyData` objects and implements a copy constructor for `ExpectData` so that copied objects don't share the same underlying iterator to `DataMap`. 

This was causing unexpected test failures in #40.

- https://github.com/ignitionrobotics/ign-physics/commit/3b480dda6e21b63cf33fa52b8aeef2c231c5aa1b adds a test that segfaults because a `SpecifyData` is copied. 
- https://github.com/ignitionrobotics/ign-physics/commit/51cfb62388e959b9d7926e753c2cf21f9f3262cb fixes the segfault, but the test fails because the copied objects share an iterator.
- https://github.com/ignitionrobotics/ign-physics/commit/aa2c61de4f9be9e8374e500724719689606a2614 Fixes the test by implementing a copy constructor and copy assignment operator for `ExpectData`. Note that implementing these for `RequiredData` is not necessary because `RequiredData` does not have any members that need special handing.

I left a TODO for implementing a move constructor for `SpecifyData` because right now, trying to move a `SpecifyData` object results in a copy. I looked into adding the constructor and move assignment operator, but since `SpecifyData` inherits from all of its template parameters, there is potential to move from an already moved from object. Here's the compiler warning I got while I was attempting to add defaulted move constructors and assignment operators to `SpecifyData`.

```
warning: defaulted move assignment for ‘ignition::physics::SpecifyData<ignition::physics::SpecifyData<ignition::physics::RequireData<StringData, BoolData, CharData>, ignition::physics::ExpectData<IntData, FloatData> >, ignition::physics::RequireData<StringData> >’ calls a non-trivial move assignment operator for virtual base ‘ignition::physics::SpecifyData<ignition::physics::RequireData<StringData, BoolData, CharData>, ignition::physics::ExpectData<IntData, FloatData> >’ [-Wvirtual-move-assign]
```
/cc @mxgrey, @diegoferigo 