### PR TITLE
testing world pose function

### DIFF
--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -136,6 +136,15 @@ math::Pose3d Entity::GetPose() const
 }
 
 //////////////////////////////////////////////////
+math::Pose3d Entity::GetWorldPose() const
+{
+  if (this->dataPtr->parent)
+    return this->dataPtr->pose + this->dataPtr->parent->GetWorldPose();
+
+  return this->dataPtr->pose;
+}
+
+//////////////////////////////////////////////////
 void Entity::SetId(std::size_t _id)
 {
   this->dataPtr->id = _id;

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -91,8 +91,12 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   public: virtual void SetPose(const math::Pose3d &_pose);
 
   /// \brief Get the pose of the entity
-  /// \return Pose of entity to set to
+  /// \return Pose of entity
   public: virtual math::Pose3d GetPose() const;
+
+  /// \brief Get the world pose of the entity
+  /// \return World pose of entity
+  public: virtual math::Pose3d GetWorldPose() const;
 
   /// \brief Get a child entity by id
   /// \param[in] _id Id of child entity

--- a/tpe/lib/src/Link_TEST.cc
+++ b/tpe/lib/src/Link_TEST.cc
@@ -19,6 +19,7 @@
 
 #include "Collision.hh"
 #include "Link.hh"
+#include "Model.hh"
 
 using namespace ignition;
 using namespace physics;
@@ -46,6 +47,15 @@ TEST(Link, BasicAPI)
   link.UpdatePose(modelPose);
   EXPECT_EQ(math::Pose3d(10, -0.312675, 2.43845, 1.23686, 0.471978, 0.918989),
             link.GetPose());
+
+  Model model;
+  model.SetPose(modelPose);
+  Entity &linkEnt = model.AddLink();
+  linkEnt.SetPose(math::Pose3d(0, 0.2, 0.5, 0, 1, 0));
+  EXPECT_EQ(math::Pose3d(10, -0.312675, 2.43845, 1.23686, 0.471978, 0.918989),
+            link.GetWorldPose());
+
+  // std::cerr << "link entity world pose " << linkEnt.GetWorldPose() << std::endl;
 
   Link link2;
   EXPECT_NE(link.GetId(), link2.GetId());


### PR DESCRIPTION
Use `pose` instead of `tf` to keep track of relative transformation. Add `GetWorldPose` to get entity pose relative to world, `GetPose` to get entity pose relative to parent. This change will make tpe more consistent with the rest of the library.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>