### PR TITLE
Integrate AABB tree for collision checking in TPE

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tpe/lib/src/aabb_tree"

--- a/tools/code_check.sh
+++ b/tools/code_check.sh
@@ -46,14 +46,15 @@ then
   QUICK_TMP=`mktemp -t asdfXXXXXXXXXX`
 else
   CHECK_DIRS="./src ./include ./test/integration ./test/regression ./test/performance ./tpe"
+  EXCLUDE_DIRS="tpe/lib/src/aabb_tree"
   if [ $CPPCHECK_LT_157 -eq 1 ]; then
     # cppcheck is older than 1.57, so don't check header files (issue #907)
-    CPPCHECK_FILES=`find $CHECK_DIRS -name "*.cc"`
+    CPPCHECK_FILES=`find $CHECK_DIRS -name "*.cc" | grep -v "$EXCLUDE_DIRS"`
   else
-    CPPCHECK_FILES=`find $CHECK_DIRS -name "*.cc" -o -name "*.hh"`
+    CPPCHECK_FILES=`find $CHECK_DIRS -name "*.cc" -o -name "*.hh" | grep -v "$EXCLUDE_DIRS"`
   fi
   CPPLINT_FILES=`\
-    find $CHECK_DIRS -name "*.cc" -o -name "*.hh" -o -name "*.c" -o -name "*.h" | grep -v -e NetUtils`
+    find $CHECK_DIRS -name "*.cc" -o -name "*.hh" -o -name "*.c" -o -name "*.h" | grep -v -e NetUtils | grep -v "$EXCLUDE_DIRS"`
 fi
 
 SUPPRESS=/tmp/cpp_check.suppress

--- a/tpe/lib/CMakeLists.txt
+++ b/tpe/lib/CMakeLists.txt
@@ -1,5 +1,12 @@
 ign_get_libsources_and_unittests(sources test_sources)
 
+set (aabb_tree_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABB.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABBTree.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABBTree.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/IAABB.h)
+set(sources ${sources} ${aabb_tree_SRC})
+
 ign_add_component(tpelib
   SOURCES ${sources}
   GET_TARGET_NAME tpelib_target
@@ -11,6 +18,7 @@ target_link_libraries(${tpelib_target}
     ignition-common${IGN_COMMON_VER}::requested
     ignition-math${IGN_MATH_VER}::eigen3
 )
+
  ign_build_tests(
   TYPE UNIT_tpelib
   SOURCES ${test_sources}

--- a/tpe/lib/CMakeLists.txt
+++ b/tpe/lib/CMakeLists.txt
@@ -2,9 +2,7 @@ ign_get_libsources_and_unittests(sources test_sources)
 
 set (aabb_tree_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABB.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABBTree.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABBTree.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/IAABB.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/aabb_tree/AABB.cc)
 set(sources ${sources} ${aabb_tree_SRC})
 
 ign_add_component(tpelib

--- a/tpe/lib/src/AABBTree.cc
+++ b/tpe/lib/src/AABBTree.cc
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <list>
+#include <stack>
+#include <unordered_map>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Profiler.hh>
+
+#include "aabb_tree/AABBTree.h"
+
+#include "AABBTree.hh"
+
+namespace ignition {
+namespace physics {
+namespace tpelib {
+
+/// \brief Private data class for AABBTreeIface
+class AABBTreeIfacePrivate
+{
+  /// \brief Pointer to the AABB tree
+  public: std::unique_ptr<AABBTree> aabbTree;
+
+  /// \brief A map of node id and its AABB object in the tree
+  public: std::unordered_map<uint64_t, std::shared_ptr<IAABB>> nodeIds;
+};
+
+}
+}
+}
+
+using namespace ignition;
+using namespace physics;
+using namespace tpelib;
+
+//////////////////////////////////////////////////
+AABBTreeIface::AABBTreeIface()
+  : dataPtr(new ::tpelib::AABBTreeIfacePrivate)
+{
+  this->dataPtr->aabbTree = std::make_unique<AABBTree>(100000);
+}
+
+//////////////////////////////////////////////////
+AABBTreeIface::~AABBTreeIface()
+{
+}
+
+//////////////////////////////////////////////////
+void AABBTreeIface::AddNode(uint64_t _id, const math::AxisAlignedBox &_aabb)
+{
+  std::shared_ptr<IAABB> obj = std::make_shared<IAABB>();
+  obj->aabb.minX = _aabb.Min().X();
+  obj->aabb.minY = _aabb.Min().Y();
+  obj->aabb.minZ = _aabb.Min().Z();
+  obj->aabb.maxX = _aabb.Max().X();
+  obj->aabb.maxY = _aabb.Max().Y();
+  obj->aabb.maxZ = _aabb.Max().Z();
+  this->dataPtr->aabbTree->insertObject(obj);
+
+  this->dataPtr->nodeIds[_id] = obj;
+}
+
+//////////////////////////////////////////////////
+bool AABBTreeIface::RemoveNode(uint64_t _id)
+{
+  auto it = this->dataPtr->nodeIds.find(_id);
+  if (it == this->dataPtr->nodeIds.end())
+  {
+    ignerr << "Unable to remove node '" << _id << "'. "
+           << "Node not found." << std::endl;
+    return false;
+  }
+
+  this->dataPtr->aabbTree->removeObject(it->second);
+  this->dataPtr->nodeIds.erase(it);
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool AABBTreeIface::UpdateNode(uint64_t _id, const math::AxisAlignedBox &_aabb)
+{
+  auto it = this->dataPtr->nodeIds.find(_id);
+  if (it == this->dataPtr->nodeIds.end())
+  {
+    ignerr << "Unable to update node '" << _id << "'. "
+           << "Node not found." << std::endl;
+    return false;
+  }
+
+  it->second->aabb.minX = _aabb.Min().X();
+  it->second->aabb.minY = _aabb.Min().Y();
+  it->second->aabb.minZ = _aabb.Min().Z();
+  it->second->aabb.maxX = _aabb.Max().X();
+  it->second->aabb.maxY = _aabb.Max().Y();
+  it->second->aabb.maxZ = _aabb.Max().Z();
+
+  this->dataPtr->aabbTree->updateObject(it->second);
+  return true;
+}
+
+
+//////////////////////////////////////////////////
+unsigned int AABBTreeIface::NodeCount() const
+{
+  return this->dataPtr->nodeIds.size();
+}
+
+//////////////////////////////////////////////////
+std::vector<uint64_t> AABBTreeIface::Collisions(uint64_t _id) const
+{
+  std::vector<uint64_t> result;
+  auto it = this->dataPtr->nodeIds.find(_id);
+  if (it == this->dataPtr->nodeIds.end())
+  {
+    ignerr << "Unable to compute collisions for node '" << _id << "'. "
+           << "Node not found." << std::endl;
+    return result;
+  }
+
+  auto list = this->dataPtr->aabbTree->queryOverlaps(it->second);
+  for (auto &objIt : list)
+  {
+    for (auto &nodeIt : this->dataPtr->nodeIds)
+    {
+      if (objIt == nodeIt.second)
+      {
+        result.push_back(nodeIt.first);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+//////////////////////////////////////////////////
+math::AxisAlignedBox AABBTreeIface::AABB(uint64_t _id) const
+{
+  auto it = this->dataPtr->nodeIds.find(_id);
+  if (it == this->dataPtr->nodeIds.end())
+  {
+    ignerr << "Unable to get AABB for node '" << _id << "'. "
+           << "Node not found." << std::endl;
+    return math::AxisAlignedBox();
+  }
+  return math::AxisAlignedBox(
+      math::Vector3d(
+      it->second->aabb.minX, it->second->aabb.minY, it->second->aabb.minZ),
+      math::Vector3d(
+      it->second->aabb.maxX, it->second->aabb.maxY, it->second->aabb.maxZ));
+}
+
+//////////////////////////////////////////////////
+bool AABBTreeIface::HasNode(uint64_t _id) const
+{
+  auto it = this->dataPtr->nodeIds.find(_id);
+  return it != this->dataPtr->nodeIds.end();
+}
+
+//////////////////////////////////////////////////
+std::string AABBTreeIface::DotGraphStr() const
+{
+/*  std::stringstream vertices;
+  std::stringstream edges;
+
+  if (this->dataPtr->root)
+  {
+    std::list<std::shared_ptr<AABBNode>> nodes;
+    nodes.push_back(this->dataPtr->root);
+    while (!nodes.empty())
+    {
+      std::shared_ptr<AABBNode> node = nodes.front();
+      nodes.pop_front();
+
+      vertices << node->id << " " << "[label=\"" << node->id << "\"];\n";
+
+      if (node->left)
+      {
+        edges << node->id << " -- " << node->left->id << ";\n";
+        nodes.push_back(node->left);
+      }
+      if (node->right)
+      {
+        edges << node->id << " -- " << node->right->id << ";\n";
+        nodes.push_back(node->right);
+      }
+    }
+  }
+
+  std::string out;
+  out += "graph {\n";
+
+  out += vertices.str();
+  out += edges.str();
+
+  out += "}";
+  return out;
+*/
+  return std::string();
+}

--- a/tpe/lib/src/AABBTree.hh
+++ b/tpe/lib/src/AABBTree.hh
@@ -22,6 +22,7 @@
 #include <set>
 
 #include <ignition/math/AxisAlignedBox.hh>
+#include <ignition/utilities/SuppressWarning.hh>
 
 #include "ignition/physics/tpelib/Export.hh"
 
@@ -76,7 +77,9 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE AABBTree
   public: bool HasNode(std::size_t _id) const;
 
   /// \brief Pointer to the private data
+  IGN_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
   private: std::unique_ptr<AABBTreePrivate> dataPtr;
+  IGN_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
 };
 }
 }

--- a/tpe/lib/src/AABBTree.hh
+++ b/tpe/lib/src/AABBTree.hh
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_PHYSICS_TPE_LIB_SRC_AABBTREE_HH_
+#define IGNITION_PHYSICS_TPE_LIB_SRC_AABBTREE_HH_
+
+#include <memory>
+#include <set>
+
+#include <ignition/math/AxisAlignedBox.hh>
+
+#include "ignition/physics/tpelib/Export.hh"
+
+namespace ignition {
+namespace physics {
+namespace tpelib {
+
+// forward declaration
+class AABBTreePrivate;
+
+class IGNITION_PHYSICS_TPELIB_VISIBLE AABBTree
+{
+  /// \brief Constructor
+  public: AABBTree();
+
+  /// \brief Destructor
+  public: ~AABBTree();
+
+  /// \brief Add a node to the tree
+  /// \param[in] _aabb Axis aligned bounding box of the node
+  /// \param[in] _id Unique id of this node
+  public: void AddNode(std::size_t _id, const math::AxisAlignedBox &_aabb);
+
+  /// \brief Remove a node from the tree
+  /// \param[in] _id Node id
+  /// \return True if the node was successfully removed, false otherwise
+  public: bool RemoveNode(std::size_t _id);
+
+  /// \brief Update a node's axis aligned bounding box
+  /// \param[in] _id Node id
+  /// \param[in] _aabb New axis aligned bounding box
+  /// \return True if the update was successful, false otherwise
+  public: bool UpdateNode(std::size_t _id, const math::AxisAlignedBox &_aabb);
+
+  /// \brief Get the number of nodes in the tree
+  /// \return Number of nodes
+  public: unsigned int NodeCount() const;
+
+  /// \brief Get all the nodes that collide / intersect with input node
+  /// \param[in] _id Input node id
+  /// \return A set of node ids that collide with the input node
+  public: std::set<std::size_t> Collisions(std::size_t _id) const;
+
+  /// \brief Get the AABB for a node
+  /// \param[in] _id Node id
+  /// \return Node's AABB
+  public: math::AxisAlignedBox AABB(std::size_t _id) const;
+
+  /// \brief Get whether the tree has a node with specified id
+  /// \param[in] _id Node id
+  /// \return True if tree has node, false otherwise
+  public: bool HasNode(std::size_t _id) const;
+
+  /// \brief Pointer to the private data
+  private: std::unique_ptr<AABBTreePrivate> dataPtr;
+};
+}
+}
+}
+
+#endif

--- a/tpe/lib/src/AABBTree_TEST.cc
+++ b/tpe/lib/src/AABBTree_TEST.cc
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "AABBTree.hh"
+
+using namespace ignition;
+using namespace physics;
+using namespace tpelib;
+
+/////////////////////////////////////////////////
+TEST(AABBTree, AABBTree)
+{
+  AABBTree tree;
+  EXPECT_EQ(0u, tree.NodeCount());
+
+  // add node
+  math::AxisAlignedBox a(-math::Vector3d::One, math::Vector3d::One);
+  std::size_t aId = 1u;
+  tree.AddNode(aId, a);
+  EXPECT_EQ(1u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(aId));
+
+  math::AxisAlignedBox b(math::Vector3d(-3, -3, -3),
+     math::Vector3d(-2, -2, -2));
+  std::size_t bId = 2u;
+  tree.AddNode(bId, b);
+  EXPECT_EQ(2u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(bId));
+
+  // c overlaps with a and b
+  math::AxisAlignedBox c(math::Vector3d(-2.5, -2.5, -2.5),
+      math::Vector3d(0.5, 0.5, 0.5));
+  std::size_t cId = 3u;
+  tree.AddNode(cId, c);
+  EXPECT_EQ(3u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(cId));
+
+  // d overlaps with a only
+  math::AxisAlignedBox d(math::Vector3d(0.55, 0.55, 0.55),
+      math::Vector3d(0.75, 0.75, 0.75));
+  std::size_t dId = 4u;
+  tree.AddNode(dId, d);
+  EXPECT_EQ(4u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(dId));
+
+  // e does not overlap with any node
+  math::AxisAlignedBox e(math::Vector3d(2.55, 2.55, 2.55),
+      math::Vector3d(3.75, 3.75, 3.75));
+  std::size_t eId = 5u;
+  tree.AddNode(eId, e);
+  EXPECT_EQ(5u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(eId));
+
+  // check collisions
+  std::set<std::size_t> result = tree.Collisions(aId);
+  EXPECT_EQ(2u, result.size());
+  EXPECT_EQ(1u, result.count(cId));
+  EXPECT_EQ(1u, result.count(dId));
+
+  result.clear();
+  result = tree.Collisions(bId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(cId));
+
+  result.clear();
+  result = tree.Collisions(cId);
+  EXPECT_EQ(2u, result.size());
+  EXPECT_EQ(1u, result.count(aId));
+  EXPECT_EQ(1u, result.count(bId));
+
+  result.clear();
+  result = tree.Collisions(dId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(aId));
+
+  result.clear();
+  result = tree.Collisions(eId);
+  EXPECT_EQ(0u, result.size());
+
+  // remove non-existent node - this should fail
+  EXPECT_FALSE(tree.RemoveNode(555u));
+
+  // remove node e
+  EXPECT_TRUE(tree.RemoveNode(eId));
+  EXPECT_EQ(4u, tree.NodeCount());
+  EXPECT_FALSE(tree.HasNode(eId));
+
+  // remove node b
+  EXPECT_TRUE(tree.RemoveNode(bId));
+  EXPECT_EQ(3u, tree.NodeCount());
+  EXPECT_FALSE(tree.HasNode(bId));
+
+  // verify collisions again
+  // collision check for b and d should fail and return 0 collisions
+  result.clear();
+  result = tree.Collisions(aId);
+  EXPECT_EQ(2u, result.size());
+  EXPECT_EQ(1u, result.count(cId));
+  EXPECT_EQ(1u, result.count(dId));
+
+  result.clear();
+  result = tree.Collisions(bId);
+  EXPECT_EQ(0u, result.size());
+
+  result.clear();
+  result = tree.Collisions(cId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(aId));
+
+  result.clear();
+  result = tree.Collisions(dId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(aId));
+
+  result.clear();
+  result = tree.Collisions(eId);
+  EXPECT_EQ(0u, result.size());
+
+  // update node c so it no longer overlaps with a or b or any other nodes
+  EXPECT_TRUE(tree.UpdateNode(cId, math::AxisAlignedBox(
+    math::Vector3d(-40, -40, -40),
+    math::Vector3d(-10, -10, -10))));
+  EXPECT_EQ(3u, tree.NodeCount());
+  EXPECT_TRUE(tree.HasNode(cId));
+
+  // verify collisions again
+  // c should have 0 collisions
+  result.clear();
+  result = tree.Collisions(aId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(dId));
+
+  result.clear();
+  result = tree.Collisions(bId);
+  EXPECT_EQ(0u, result.size());
+
+  result.clear();
+  result = tree.Collisions(cId);
+  EXPECT_EQ(0u, result.size());
+
+  result.clear();
+  result = tree.Collisions(dId);
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(1u, result.count(aId));
+
+  result.clear();
+  result = tree.Collisions(eId);
+  EXPECT_EQ(0u, result.size());
+}

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -15,17 +15,40 @@
  *
 */
 
-#include <unordered_map>
+#include <set>
 
 #include <ignition/common/Profiler.hh>
 
 #include "CollisionDetector.hh"
 #include "Utils.hh"
 
+#include "aabb_tree/AABBTree.h"
+#include "aabb_tree/IAABB.h"
+
+/// \brief Private data class for CollisionDetector
+class ignition::physics::tpelib::CollisionDetectorPrivate
+{
+  /// \brief AABB tree
+  public: AABBTreeIface aabbTree;
+
+  /// \brief Set of entity id
+  public: std::set<std::size_t> nodeIds;
+};
+
 using namespace ignition;
 using namespace physics;
 using namespace tpelib;
 
+//////////////////////////////////////////////////
+CollisionDetector::CollisionDetector()
+  : dataPtr(new CollisionDetectorPrivate)
+{
+}
+
+//////////////////////////////////////////////////
+CollisionDetector::~CollisionDetector()
+{
+}
 
 //////////////////////////////////////////////////
 std::vector<Contact> CollisionDetector::CheckCollisions(
@@ -33,73 +56,82 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
     bool _singleContact)
 {
   IGN_PROFILE("tpelib::CollisionDetector::CheckCollisions");
+
   // contacts to be filled and returned
   std::vector<Contact> contacts;
 
-  // cache of axis aligned box in world frame
-  std::unordered_map<std::size_t, math::AxisAlignedBox> worldAabb;
+  // update AABB tree
+  // remove nodes that no longer exist
+  auto nodesToCheckForRemoval = this->dataPtr->nodeIds;
+  for (auto id : nodesToCheckForRemoval)
+  {
+    if (_entities.find(id) == _entities.end())
+    {
+      this->dataPtr->aabbTree.RemoveNode(id);
+      this->dataPtr->nodeIds.erase(id);
+    }
+  }
 
   for (auto it = _entities.begin(); it != _entities.end(); ++it)
   {
-    std::shared_ptr<Entity> e1 = it->second;
-
-    // Get collide bitmask for enitty 1
-    uint16_t cb1 = e1->GetCollideBitmask();
-
-    // Get world axis aligned box for entity 1
-    math::AxisAlignedBox wb1;
-    auto wb1It = worldAabb.find(e1->GetId());
-    if (wb1It == worldAabb.end())
+    std::shared_ptr<Entity> e = it->second;
+    // add new nodes
+    if (!this->dataPtr->aabbTree.HasNode(it->first))
     {
-      // get bbox in local frame
-      math::AxisAlignedBox b1 = e1->GetBoundingBox();
+      math::AxisAlignedBox b = e->GetBoundingBox();
       // convert to world aabb
-      math::Pose3d p1 = e1->GetPose();
-      wb1 = transformAxisAlignedBox(b1, p1);
-      worldAabb[e1->GetId()] = wb1;
-    }
-    else
-    {
-      wb1 = wb1It->second;
-    }
+      math::AxisAlignedBox aabb;
+      math::Pose3d p = e->GetPose();
+      aabb = transformAxisAlignedBox(b, p);
+      this->dataPtr->aabbTree.AddNode(e->GetId(), aabb);
 
-    for (auto it2 = std::next(it, 1); it2 != _entities.end(); ++it2)
+      this->dataPtr->nodeIds.insert(it->first);
+    }
+    // update existing nodes
+    else if (e->PoseDirty())
     {
-      std::shared_ptr<Entity> e2 = it2->second;
+      math::AxisAlignedBox b = e->GetBoundingBox();
+      // convert to world aabb
+      math::AxisAlignedBox aabb;
+      math::Pose3d p = e->GetPose();
+      aabb = transformAxisAlignedBox(b, p);
+      this->dataPtr->aabbTree.UpdateNode(e->GetId(), aabb);
+    }
+  }
 
+  // query AABB tree for collisions
+  for (auto it = _entities.begin(); it != _entities.end(); ++it)
+  {
+    std::shared_ptr<Entity> e = it->second;
+
+    auto result = this->dataPtr->aabbTree.Collisions(e->GetId());
+    if (result.empty())
+      continue;
+
+    math::AxisAlignedBox wb1 = this->dataPtr->aabbTree.AABB(e->GetId());
+
+    // Get collide bitmask for entity 1
+    uint16_t cb1 = e->GetCollideBitmask();
+
+    // Check intersection
+    for (const auto &nId : result)
+    {
       // Get collide bitmask for entity 2
-      uint16_t cb2 = e2->GetCollideBitmask();
+      uint16_t cb2 = _entities.at(nId)->GetCollideBitmask();
 
       // collision filtering using collide bitmask
       if ((cb1 & cb2) == 0)
         continue;
 
-      // Get world axis aligned box for entity 2
-      math::AxisAlignedBox wb2;
-      auto wb2It = worldAabb.find(e2->GetId());
-      if (wb2It == worldAabb.end())
-      {
-        // get bbox in local frame
-        math::AxisAlignedBox b2 = e2->GetBoundingBox();
-        // convert to world aabb
-        math::Pose3d p2 = e2->GetPose();
-        wb2 = transformAxisAlignedBox(b2, p2);
-        worldAabb[e2->GetId()] = wb2;
-      }
-      else
-      {
-        wb2 = wb2It->second;
-      }
-
-      // Check intersection
       std::vector<math::Vector3d> points;
+      math::AxisAlignedBox wb2 = this->dataPtr->aabbTree.AABB(nId);
       if (this->GetIntersectionPoints(wb1, wb2, points, _singleContact))
       {
         Contact c;
         // TPE checks collisions in the model level so contacts are associated
         // with models and not collisions!
-        c.entity1 = e1->GetId();
-        c.entity2 = e2->GetId();
+        c.entity1 = e->GetId();
+        c.entity2 = nId;
         for (const auto &p : points)
         {
           c.point = p;
@@ -108,14 +140,110 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
       }
     }
   }
+
+  std::cerr << "contacts ===== " << contacts.size() << std::endl;
   return contacts;
 }
+
+
+// //////////////////////////////////////////////////
+// std::vector<Contact> CollisionDetector::CheckCollisions(
+//     const std::map<std::size_t, std::shared_ptr<Entity>> &_entities,
+//     bool _singleContact)
+// {
+//   IGN_PROFILE("CollisionDetector::CheckCollisions");
+//
+//   // contacts to be filled and returned
+//   std::vector<Contact> contacts;
+//
+//   // cache of axis aligned box in world frame
+//   std::unordered_map<std::size_t, math::AxisAlignedBox> worldAabb;
+//
+//   for (auto it = _entities.begin(); it != _entities.end(); ++it)
+//   {
+//     std::shared_ptr<Entity> e1 = it->second;
+//
+//     // Get collide bitmask for enitty 1
+//     uint16_t cb1 = e1->GetCollideBitmask();
+//
+//     // Get world axis aligned box for entity 1
+//     math::AxisAlignedBox wb1;
+//     auto wb1It = worldAabb.find(e1->GetId());
+//     if (wb1It == worldAabb.end())
+//     {
+//       // get bbox in local frame
+//       math::AxisAlignedBox b1 = e1->GetBoundingBox();
+//       // convert to world aabb
+//       math::Pose3d p1 = e1->GetPose();
+//       wb1 = transformAxisAlignedBox(b1, p1);
+//       worldAabb[e1->GetId()] = wb1;
+//     }
+//     else
+//     {
+//       wb1 = wb1It->second;
+//     }
+//
+//     for (auto it2 = std::next(it, 1); it2 != _entities.end(); ++it2)
+//     {
+//       std::shared_ptr<Entity> e2 = it2->second;
+//
+// //      IGN_PROFILE_BEGIN("CollisionDetector GetCollideBitMask");
+//       // Get collide bitmask for entity 2
+//       uint16_t cb2 = e2->GetCollideBitmask();
+// //      IGN_PROFILE_END();
+//
+//       // collision filtering using collide bitmask
+//       if ((cb1 & cb2) == 0)
+//         continue;
+//
+//       IGN_PROFILE_BEGIN("CollisionDetector find bbox");
+//       // Get world axis aligned box for entity 2
+//       math::AxisAlignedBox wb2;
+//       auto wb2It = worldAabb.find(e2->GetId());
+//       IGN_PROFILE_END();
+//
+//       if (wb2It == worldAabb.end())
+//       {
+//         // get bbox in local frame
+//         math::AxisAlignedBox b2 = e2->GetBoundingBox();
+//         // convert to world aabb
+//         math::Pose3d p2 = e2->GetPose();
+//         wb2 = transformAxisAlignedBox(b2, p2);
+//         worldAabb[e2->GetId()] = wb2;
+//       }
+//       else
+//       {
+//         wb2 = wb2It->second;
+//       }
+//
+//       // Check intersection
+//       std::vector<math::Vector3d> points;
+//       if (this->GetIntersectionPoints(wb1, wb2, points, _singleContact))
+//       {
+//         std::cerr << "got intersection " << std::endl;
+//         Contact c;
+//         // TPE checks collisions in the model level so contacts are associated
+//         // with models and not collisions!
+//         c.entity1 = e1->GetId();
+//         c.entity2 = e2->GetId();
+//         for (const auto &p : points)
+//         {
+//           c.point = p;
+//           contacts.push_back(c);
+//         }
+//       }
+//     }
+//   }
+//
+//   return contacts;
+// }
 
 //////////////////////////////////////////////////
 bool CollisionDetector::GetIntersectionPoints(const math::AxisAlignedBox &_b1,
     const math::AxisAlignedBox &_b2,
     std::vector<math::Vector3d> &_points, bool _singleContact)
 {
+  IGN_PROFILE("CollisionDetector::GetIntersectionPoints");
   // fast intersection check
   if (_b1.Intersects(_b2))
   {

--- a/tpe/lib/src/CollisionDetector.hh
+++ b/tpe/lib/src/CollisionDetector.hh
@@ -85,7 +85,9 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE CollisionDetector
       bool _singleContact = false);
 
   /// \brief Pointer to private data
+  IGN_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
   private: std::unique_ptr<CollisionDetectorPrivate> dataPtr;
+  IGN_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
 };
 
 }

--- a/tpe/lib/src/CollisionDetector.hh
+++ b/tpe/lib/src/CollisionDetector.hh
@@ -30,9 +30,14 @@
 
 #include "Entity.hh"
 
+#include "AABBTree.hh"
+
 namespace ignition {
 namespace physics {
 namespace tpelib {
+
+// forward declaration
+class CollisionDetectorPrivate;
 
 /// \brief A data structure to store contact properties
 class IGNITION_PHYSICS_TPELIB_VISIBLE Contact
@@ -53,10 +58,10 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Contact
 class IGNITION_PHYSICS_TPELIB_VISIBLE CollisionDetector
 {
   /// \brief Constructor
-  public: CollisionDetector() = default;
+  public: CollisionDetector();
 
   /// \brief Destructor
-  public: ~CollisionDetector() = default;
+  public: ~CollisionDetector();
 
   /// \brief Check collisions between a list entities and get all contact points
   /// \param[in] _entities List of entities
@@ -78,6 +83,9 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE CollisionDetector
       const math::AxisAlignedBox &_b2,
       std::vector<math::Vector3d> &_points,
       bool _singleContact = false);
+
+  /// \brief Pointer to private data
+  private: std::unique_ptr<CollisionDetectorPrivate> dataPtr;
 };
 
 }

--- a/tpe/lib/src/CollisionDetector_TEST.cc
+++ b/tpe/lib/src/CollisionDetector_TEST.cc
@@ -233,4 +233,11 @@ TEST(CollisionDetector, CheckCollisions)
   // check single contact point
   contacts = cd.CheckCollisions(entities, true);
   EXPECT_EQ(3u, contacts.size());
+
+  // remove entity and check again
+  entities.erase(modelC->GetId());
+  contacts = cd.CheckCollisions(entities, false);
+  EXPECT_EQ(8u, contacts.size());
+  contacts = cd.CheckCollisions(entities, true);
+  EXPECT_EQ(1u, contacts.size());
 }

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -323,7 +323,7 @@ bool Entity::PoseDirty() const
 }
 
 //////////////////////////////////////////////////
-void Entity::ClearPoseDirty()
+void Entity::ResetPoseDirty()
 {
   this->dataPtr->poseDirty = false;
 }

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -42,6 +42,9 @@ class ignition::physics::tpelib::EntityPrivate
   /// \brief Flag to indicate if bounding box changed
   public: bool bboxDirty = true;
 
+  /// \brief Flag to indicate if pose changed
+  public: bool poseDirty = false;
+
   /// \brief Flag to indicate if collide bitmask changed
   public: bool collideBitmaskDirty = true;
 
@@ -127,6 +130,7 @@ const std::string &Entity::GetNameRef() const
 void Entity::SetPose(const math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
+  this->dataPtr->poseDirty = true;
 }
 
 //////////////////////////////////////////////////
@@ -310,4 +314,16 @@ void Entity::SetParent(Entity *_parent)
 Entity *Entity::GetParent() const
 {
   return this->dataPtr->parent;
+}
+
+//////////////////////////////////////////////////
+bool Entity::PoseDirty() const
+{
+  return this->dataPtr->poseDirty = true;
+}
+
+//////////////////////////////////////////////////
+void Entity::ClearPoseDirty()
+{
+  this->dataPtr->poseDirty = false;
 }

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -150,6 +150,15 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   public: Entity *GetParent() const;
 
   /// \internal
+  /// \brief Get whether the pose has changed
+  /// \return True if pose has changed, false otherwise
+  public: bool PoseDirty() const;
+
+  /// \internal
+  /// \brief Clear the pose dirty flag
+  public: void ClearPoseDirty();
+
+  /// \internal
   /// \brief Mark that the children of the entity has changed, e.g. a child
   /// entity is added or removed, or child entity properties changed.
   public: void ChildrenChanged();

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -155,8 +155,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   public: bool PoseDirty() const;
 
   /// \internal
-  /// \brief Clear the pose dirty flag
-  public: void ClearPoseDirty();
+  /// \brief Reset the pose dirty flag
+  public: void ResetPoseDirty();
 
   /// \internal
   /// \brief Mark that the children of the entity has changed, e.g. a child

--- a/tpe/lib/src/Model.cc
+++ b/tpe/lib/src/Model.cc
@@ -92,6 +92,11 @@ void Model::UpdatePose(
   const math::Vector3d _angularVelocity)
 {
   IGN_PROFILE("tpelib::Model::UpdatePose");
+
+  if (_linearVelocity == math::Vector3d::Zero &&
+      _angularVelocity == math::Vector3d::Zero)
+    return;
+
   math::Pose3d currentPose = this->GetPose();
   math::Pose3d nextPose(
     currentPose.Pos() + _linearVelocity * _timeStep,

--- a/tpe/lib/src/World.cc
+++ b/tpe/lib/src/World.cc
@@ -79,7 +79,7 @@ void World::Step()
       this->collisionDetector.CheckCollisions(children, true));
 
   for (auto it = children.begin(); it != children.end(); ++it)
-    it->second->ClearPoseDirty();
+    it->second->ResetPoseDirty();
 
   // increment world time by step size
   this->time += this->timeStep;

--- a/tpe/lib/src/World.cc
+++ b/tpe/lib/src/World.cc
@@ -78,6 +78,9 @@ void World::Step()
   this->contacts = std::move(
       this->collisionDetector.CheckCollisions(children, true));
 
+  for (auto it = children.begin(); it != children.end(); ++it)
+    it->second->ClearPoseDirty();
+
   // increment world time by step size
   this->time += this->timeStep;
 }

--- a/tpe/lib/src/aabb_tree/AABB.cc
+++ b/tpe/lib/src/aabb_tree/AABB.cc
@@ -1215,18 +1215,19 @@ namespace aabb
 
         for (unsigned int i=0;i<dimension;i++)
         {
+            int periodicityVal = static_cast<int>(periodicity[i]);
             if (separation[i] < negMinImage[i])
             {
-                separation[i] += periodicity[i]*boxSize[i];
-                shift[i] = periodicity[i]*boxSize[i];
+                separation[i] += periodicityVal*boxSize[i];
+                shift[i] = periodicityVal*boxSize[i];
                 isShifted = true;
             }
             else
             {
                 if (separation[i] >= posMinImage[i])
                 {
-                    separation[i] -= periodicity[i]*boxSize[i];
-                    shift[i] = -periodicity[i]*boxSize[i];
+                    separation[i] -= periodicityVal*boxSize[i];
+                    shift[i] = -periodicityVal*boxSize[i];
                     isShifted = true;
                 }
             }

--- a/tpe/lib/src/aabb_tree/AABB.cc
+++ b/tpe/lib/src/aabb_tree/AABB.cc
@@ -1,0 +1,1237 @@
+/*
+  Copyright (c) 2009 Erin Catto http://www.box2d.org
+  Copyright (c) 2016-2018 Lester Hedges <lester.hedges+aabbcc@gmail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+  3. This notice may not be removed or altered from any source distribution.
+
+  This code was adapted from parts of the Box2D Physics Engine,
+  http://www.box2d.org
+*/
+
+#include <cmath>
+#include "AABB.h"
+
+namespace aabb
+{
+    AABB::AABB()
+    {
+    }
+
+    AABB::AABB(unsigned int dimension)
+    {
+        assert(dimension >= 2);
+
+        lowerBound.resize(dimension);
+        upperBound.resize(dimension);
+    }
+
+    AABB::AABB(const std::vector<double>& lowerBound_, const std::vector<double>& upperBound_) :
+        lowerBound(lowerBound_), upperBound(upperBound_)
+    {
+        // Validate the dimensionality of the bounds vectors.
+        if (lowerBound.size() != upperBound.size())
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // Validate that the upper bounds exceed the lower bounds.
+        for (unsigned int i=0;i<lowerBound.size();i++)
+        {
+            // Validate the bound.
+            if (lowerBound[i] > upperBound[i])
+            {
+                throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
+            }
+        }
+
+        surfaceArea = computeSurfaceArea();
+        centre = computeCentre();
+    }
+
+    double AABB::computeSurfaceArea() const
+    {
+        // Sum of "area" of all the sides.
+        double sum = 0;
+
+        // General formula for one side: hold one dimension constant
+        // and multiply by all the other ones.
+        for (unsigned int d1 = 0; d1 < lowerBound.size(); d1++)
+        {
+            // "Area" of current side.
+            double product = 1;
+
+            for (unsigned int d2 = 0; d2 < lowerBound.size(); d2++)
+            {
+                if (d1 == d2)
+                    continue;
+
+                double dx = upperBound[d2] - lowerBound[d2];
+                product *= dx;
+            }
+
+            // Update the sum.
+            sum += product;
+        }
+
+        return 2.0 * sum;
+    }
+
+    double AABB::getSurfaceArea() const
+    {
+        return surfaceArea;
+    }
+
+    void AABB::merge(const AABB& aabb1, const AABB& aabb2)
+    {
+        assert(aabb1.lowerBound.size() == aabb2.lowerBound.size());
+        assert(aabb1.upperBound.size() == aabb2.upperBound.size());
+
+        lowerBound.resize(aabb1.lowerBound.size());
+        upperBound.resize(aabb1.lowerBound.size());
+
+        for (unsigned int i=0;i<lowerBound.size();i++)
+        {
+            lowerBound[i] = std::min(aabb1.lowerBound[i], aabb2.lowerBound[i]);
+            upperBound[i] = std::max(aabb1.upperBound[i], aabb2.upperBound[i]);
+        }
+
+        surfaceArea = computeSurfaceArea();
+        centre = computeCentre();
+    }
+
+    bool AABB::contains(const AABB& aabb) const
+    {
+        assert(aabb.lowerBound.size() == lowerBound.size());
+
+        for (unsigned int i=0;i<lowerBound.size();i++)
+        {
+            if (aabb.lowerBound[i] < lowerBound[i]) return false;
+            if (aabb.upperBound[i] > upperBound[i]) return false;
+        }
+
+        return true;
+    }
+
+    bool AABB::overlaps(const AABB& aabb, bool touchIsOverlap) const
+    {
+        assert(aabb.lowerBound.size() == lowerBound.size());
+
+        bool rv = true;
+
+        if (touchIsOverlap)
+        {
+            for (unsigned int i = 0; i < lowerBound.size(); ++i)
+            {
+                if (aabb.upperBound[i] < lowerBound[i] || aabb.lowerBound[i] > upperBound[i])
+                {
+                    rv = false;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            for (unsigned int i = 0; i < lowerBound.size(); ++i)
+            {
+                if (aabb.upperBound[i] <= lowerBound[i] || aabb.lowerBound[i] >= upperBound[i])
+                {
+                    rv = false;
+                    break;
+                }
+            }
+        }
+
+        return rv;
+    }
+
+    std::vector<double> AABB::computeCentre()
+    {
+        std::vector<double> position(lowerBound.size());
+
+        for (unsigned int i=0;i<position.size();i++)
+            position[i] = 0.5 * (lowerBound[i] + upperBound[i]);
+
+        return position;
+    }
+
+    void AABB::setDimension(unsigned int dimension)
+    {
+        assert(dimension >= 2);
+
+        lowerBound.resize(dimension);
+        upperBound.resize(dimension);
+    }
+
+    Node::Node()
+    {
+    }
+
+    bool Node::isLeaf() const
+    {
+        return (left == NULL_NODE);
+    }
+
+    Tree::Tree(unsigned int dimension_,
+               double skinThickness_,
+               unsigned int nParticles,
+               bool touchIsOverlap_) :
+        dimension(dimension_), isPeriodic(false), skinThickness(skinThickness_),
+        touchIsOverlap(touchIsOverlap_)
+    {
+        // Validate the dimensionality.
+        if ((dimension < 2))
+        {
+            throw std::invalid_argument("[ERROR]: Invalid dimensionality!");
+        }
+
+        // Initialise the periodicity vector.
+        periodicity.resize(dimension);
+        std::fill(periodicity.begin(), periodicity.end(), false);
+
+        // Initialise the tree.
+        root = NULL_NODE;
+        nodeCount = 0;
+        nodeCapacity = nParticles;
+        nodes.resize(nodeCapacity);
+
+        // Build a linked list for the list of free nodes.
+        for (unsigned int i=0;i<nodeCapacity-1;i++)
+        {
+            nodes[i].next = i + 1;
+            nodes[i].height = -1;
+        }
+        nodes[nodeCapacity-1].next = NULL_NODE;
+        nodes[nodeCapacity-1].height = -1;
+
+        // Assign the index of the first free node.
+        freeList = 0;
+    }
+
+    Tree::Tree(unsigned int dimension_,
+               double skinThickness_,
+               const std::vector<bool>& periodicity_,
+               const std::vector<double>& boxSize_,
+               unsigned int nParticles,
+               bool touchIsOverlap_) :
+        dimension(dimension_), skinThickness(skinThickness_),
+        periodicity(periodicity_), boxSize(boxSize_),
+        touchIsOverlap(touchIsOverlap_)
+    {
+        // Validate the dimensionality.
+        if (dimension < 2)
+        {
+            throw std::invalid_argument("[ERROR]: Invalid dimensionality!");
+        }
+
+        // Validate the dimensionality of the vectors.
+        if ((periodicity.size() != dimension) || (boxSize.size() != dimension))
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // Initialise the tree.
+        root = NULL_NODE;
+        touchIsOverlap = true;
+        nodeCount = 0;
+        nodeCapacity = nParticles;
+        nodes.resize(nodeCapacity);
+
+        // Build a linked list for the list of free nodes.
+        for (unsigned int i=0;i<nodeCapacity-1;i++)
+        {
+            nodes[i].next = i + 1;
+            nodes[i].height = -1;
+        }
+        nodes[nodeCapacity-1].next = NULL_NODE;
+        nodes[nodeCapacity-1].height = -1;
+
+        // Assign the index of the first free node.
+        freeList = 0;
+
+        // Check periodicity.
+        isPeriodic = false;
+        posMinImage.resize(dimension);
+        negMinImage.resize(dimension);
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            posMinImage[i] =  0.5*boxSize[i];
+            negMinImage[i] = -0.5*boxSize[i];
+
+            if (periodicity[i])
+                isPeriodic = true;
+        }
+    }
+
+    void Tree::setPeriodicity(const std::vector<bool>& periodicity_)
+    {
+        periodicity = periodicity_;
+    }
+
+    void Tree::setBoxSize(const std::vector<double>& boxSize_)
+    {
+        boxSize = boxSize_;
+    }
+
+    unsigned int Tree::allocateNode()
+    {
+        // Exand the node pool as needed.
+        if (freeList == NULL_NODE)
+        {
+            assert(nodeCount == nodeCapacity);
+
+            // The free list is empty. Rebuild a bigger pool.
+            nodeCapacity *= 2;
+            nodes.resize(nodeCapacity);
+
+            // Build a linked list for the list of free nodes.
+            for (unsigned int i=nodeCount;i<nodeCapacity-1;i++)
+            {
+                nodes[i].next = i + 1;
+                nodes[i].height = -1;
+            }
+            nodes[nodeCapacity-1].next = NULL_NODE;
+            nodes[nodeCapacity-1].height = -1;
+
+            // Assign the index of the first free node.
+            freeList = nodeCount;
+        }
+
+        // Peel a node off the free list.
+        unsigned int node = freeList;
+        freeList = nodes[node].next;
+        nodes[node].parent = NULL_NODE;
+        nodes[node].left = NULL_NODE;
+        nodes[node].right = NULL_NODE;
+        nodes[node].height = 0;
+        nodes[node].aabb.setDimension(dimension);
+        nodeCount++;
+
+        return node;
+    }
+
+    void Tree::freeNode(unsigned int node)
+    {
+        assert(node < nodeCapacity);
+        assert(0 < nodeCount);
+
+        nodes[node].next = freeList;
+        nodes[node].height = -1;
+        freeList = node;
+        nodeCount--;
+    }
+
+    void Tree::insertParticle(unsigned int particle, std::vector<double>& position, double radius)
+    {
+        // Make sure the particle doesn't already exist.
+        if (particleMap.count(particle) != 0)
+        {
+            throw std::invalid_argument("[ERROR]: Particle already exists in tree!");
+        }
+
+        // Validate the dimensionality of the position vector.
+        if (position.size() != dimension)
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // Allocate a new node for the particle.
+        unsigned int node = allocateNode();
+
+        // AABB size in each dimension.
+        std::vector<double> size(dimension);
+
+        // Compute the AABB limits.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            nodes[node].aabb.lowerBound[i] = position[i] - radius;
+            nodes[node].aabb.upperBound[i] = position[i] + radius;
+            size[i] = nodes[node].aabb.upperBound[i] - nodes[node].aabb.lowerBound[i];
+        }
+
+        // Fatten the AABB.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            nodes[node].aabb.lowerBound[i] -= skinThickness * size[i];
+            nodes[node].aabb.upperBound[i] += skinThickness * size[i];
+        }
+        nodes[node].aabb.surfaceArea = nodes[node].aabb.computeSurfaceArea();
+        nodes[node].aabb.centre = nodes[node].aabb.computeCentre();
+
+        // Zero the height.
+        nodes[node].height = 0;
+
+        // Insert a new leaf into the tree.
+        insertLeaf(node);
+
+        // Add the new particle to the map.
+        particleMap.insert(std::unordered_map<unsigned int, unsigned int>::value_type(particle, node));
+
+        // Store the particle index.
+        nodes[node].particle = particle;
+    }
+
+    void Tree::insertParticle(unsigned int particle, std::vector<double>& lowerBound, std::vector<double>& upperBound)
+    {
+        // Make sure the particle doesn't already exist.
+        if (particleMap.count(particle) != 0)
+        {
+            throw std::invalid_argument("[ERROR]: Particle already exists in tree!");
+        }
+
+        // Validate the dimensionality of the bounds vectors.
+        if ((lowerBound.size() != dimension) || (upperBound.size() != dimension))
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // Allocate a new node for the particle.
+        unsigned int node = allocateNode();
+
+        // AABB size in each dimension.
+        std::vector<double> size(dimension);
+
+        // Compute the AABB limits.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            // Validate the bound.
+            if (lowerBound[i] > upperBound[i])
+            {
+                throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
+            }
+
+            nodes[node].aabb.lowerBound[i] = lowerBound[i];
+            nodes[node].aabb.upperBound[i] = upperBound[i];
+            size[i] = upperBound[i] - lowerBound[i];
+        }
+
+        // Fatten the AABB.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            nodes[node].aabb.lowerBound[i] -= skinThickness * size[i];
+            nodes[node].aabb.upperBound[i] += skinThickness * size[i];
+        }
+        nodes[node].aabb.surfaceArea = nodes[node].aabb.computeSurfaceArea();
+        nodes[node].aabb.centre = nodes[node].aabb.computeCentre();
+
+        // Zero the height.
+        nodes[node].height = 0;
+
+        // Insert a new leaf into the tree.
+        insertLeaf(node);
+
+        // Add the new particle to the map.
+        particleMap.insert(std::unordered_map<unsigned int, unsigned int>::value_type(particle, node));
+
+        // Store the particle index.
+        nodes[node].particle = particle;
+    }
+
+    unsigned int Tree::nParticles()
+    {
+        return particleMap.size();
+    }
+
+    void Tree::removeParticle(unsigned int particle)
+    {
+        // Map iterator.
+        std::unordered_map<unsigned int, unsigned int>::iterator it;
+
+        // Find the particle.
+        it = particleMap.find(particle);
+
+        // The particle doesn't exist.
+        if (it == particleMap.end())
+        {
+            throw std::invalid_argument("[ERROR]: Invalid particle index!");
+        }
+
+        // Extract the node index.
+        unsigned int node = it->second;
+
+        // Erase the particle from the map.
+        particleMap.erase(it);
+
+        assert(node < nodeCapacity);
+        assert(nodes[node].isLeaf());
+
+        removeLeaf(node);
+        freeNode(node);
+    }
+
+    void Tree::removeAll()
+    {
+        // Iterator pointing to the start of the particle map.
+        std::unordered_map<unsigned int, unsigned int>::iterator it = particleMap.begin();
+
+        // Iterate over the map.
+        while (it != particleMap.end())
+        {
+            // Extract the node index.
+            unsigned int node = it->second;
+
+            assert(node < nodeCapacity);
+            assert(nodes[node].isLeaf());
+
+            removeLeaf(node);
+            freeNode(node);
+
+            it++;
+        }
+
+        // Clear the particle map.
+        particleMap.clear();
+    }
+
+    bool Tree::updateParticle(unsigned int particle, std::vector<double>& position, double radius,
+                              bool alwaysReinsert)
+    {
+        // Validate the dimensionality of the position vector.
+        if (position.size() != dimension)
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // AABB bounds vectors.
+        std::vector<double> lowerBound(dimension);
+        std::vector<double> upperBound(dimension);
+
+        // Compute the AABB limits.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            lowerBound[i] = position[i] - radius;
+            upperBound[i] = position[i] + radius;
+        }
+
+        // Update the particle.
+        return updateParticle(particle, lowerBound, upperBound, alwaysReinsert);
+    }
+
+    bool Tree::updateParticle(unsigned int particle, std::vector<double>& lowerBound,
+                              std::vector<double>& upperBound, bool alwaysReinsert)
+    {
+        // Validate the dimensionality of the bounds vectors.
+        if ((lowerBound.size() != dimension) && (upperBound.size() != dimension))
+        {
+            throw std::invalid_argument("[ERROR]: Dimensionality mismatch!");
+        }
+
+        // Map iterator.
+        std::unordered_map<unsigned int, unsigned int>::iterator it;
+
+        // Find the particle.
+        it = particleMap.find(particle);
+
+        // The particle doesn't exist.
+        if (it == particleMap.end())
+        {
+            throw std::invalid_argument("[ERROR]: Invalid particle index!");
+        }
+
+        // Extract the node index.
+        unsigned int node = it->second;
+
+        assert(node < nodeCapacity);
+        assert(nodes[node].isLeaf());
+
+        // AABB size in each dimension.
+        std::vector<double> size(dimension);
+
+        // Compute the AABB limits.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            // Validate the bound.
+            if (lowerBound[i] > upperBound[i])
+            {
+                throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
+            }
+
+            size[i] = upperBound[i] - lowerBound[i];
+        }
+
+        // Create the new AABB.
+        AABB aabb(lowerBound, upperBound);
+
+        // No need to update if the particle is still within its fattened AABB.
+        if (!alwaysReinsert && nodes[node].aabb.contains(aabb)) return false;
+
+        // Remove the current leaf.
+        removeLeaf(node);
+
+        // Fatten the new AABB.
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            aabb.lowerBound[i] -= skinThickness * size[i];
+            aabb.upperBound[i] += skinThickness * size[i];
+        }
+
+        // Assign the new AABB.
+        nodes[node].aabb = aabb;
+
+        // Update the surface area and centroid.
+        nodes[node].aabb.surfaceArea = nodes[node].aabb.computeSurfaceArea();
+        nodes[node].aabb.centre = nodes[node].aabb.computeCentre();
+
+        // Insert a new leaf node.
+        insertLeaf(node);
+
+        return true;
+    }
+
+    std::vector<unsigned int> Tree::query(unsigned int particle)
+    {
+        // Make sure that this is a valid particle.
+        if (particleMap.count(particle) == 0)
+        {
+            throw std::invalid_argument("[ERROR]: Invalid particle index!");
+        }
+
+        // Test overlap of particle AABB against all other particles.
+        return query(particle, nodes[particleMap.find(particle)->second].aabb);
+    }
+
+    std::vector<unsigned int> Tree::query(unsigned int particle, const AABB& aabb)
+    {
+        std::vector<unsigned int> stack;
+        stack.reserve(256);
+        stack.push_back(root);
+
+        std::vector<unsigned int> particles;
+
+        while (stack.size() > 0)
+        {
+            unsigned int node = stack.back();
+            stack.pop_back();
+
+            // Copy the AABB.
+            AABB nodeAABB = nodes[node].aabb;
+
+            if (node == NULL_NODE) continue;
+
+            if (isPeriodic)
+            {
+                std::vector<double> separation(dimension);
+                std::vector<double> shift(dimension);
+                for (unsigned int i=0;i<dimension;i++)
+                    separation[i] = nodeAABB.centre[i] - aabb.centre[i];
+
+                bool isShifted = minimumImage(separation, shift);
+
+                // Shift the AABB.
+                if (isShifted)
+                {
+                    for (unsigned int i=0;i<dimension;i++)
+                    {
+                        nodeAABB.lowerBound[i] += shift[i];
+                        nodeAABB.upperBound[i] += shift[i];
+                    }
+                }
+            }
+
+            // Test for overlap between the AABBs.
+            if (aabb.overlaps(nodeAABB, touchIsOverlap))
+            {
+                // Check that we're at a leaf node.
+                if (nodes[node].isLeaf())
+                {
+                    // Can't interact with itself.
+                    if (nodes[node].particle != particle)
+                    {
+                        particles.push_back(nodes[node].particle);
+                    }
+                }
+                else
+                {
+                    stack.push_back(nodes[node].left);
+                    stack.push_back(nodes[node].right);
+                }
+            }
+        }
+
+        return particles;
+    }
+
+    std::vector<unsigned int> Tree::query(const AABB& aabb)
+    {
+        // Make sure the tree isn't empty.
+        if (particleMap.size() == 0)
+        {
+            return std::vector<unsigned int>();
+        }
+
+        // Test overlap of AABB against all particles.
+        return query(std::numeric_limits<unsigned int>::max(), aabb);
+    }
+
+    const AABB& Tree::getAABB(unsigned int particle)
+    {
+        return nodes[particleMap[particle]].aabb;
+    }
+
+    void Tree::insertLeaf(unsigned int leaf)
+    {
+        if (root == NULL_NODE)
+        {
+            root = leaf;
+            nodes[root].parent = NULL_NODE;
+            return;
+        }
+
+        // Find the best sibling for the node.
+
+        AABB leafAABB = nodes[leaf].aabb;
+        unsigned int index = root;
+
+        while (!nodes[index].isLeaf())
+        {
+            // Extract the children of the node.
+            unsigned int left  = nodes[index].left;
+            unsigned int right = nodes[index].right;
+
+            double surfaceArea = nodes[index].aabb.getSurfaceArea();
+
+            AABB combinedAABB;
+            combinedAABB.merge(nodes[index].aabb, leafAABB);
+            double combinedSurfaceArea = combinedAABB.getSurfaceArea();
+
+            // Cost of creating a new parent for this node and the new leaf.
+            double cost = 2.0 * combinedSurfaceArea;
+
+            // Minimum cost of pushing the leaf further down the tree.
+            double inheritanceCost = 2.0 * (combinedSurfaceArea - surfaceArea);
+
+            // Cost of descending to the left.
+            double costLeft;
+            if (nodes[left].isLeaf())
+            {
+                AABB aabb;
+                aabb.merge(leafAABB, nodes[left].aabb);
+                costLeft = aabb.getSurfaceArea() + inheritanceCost;
+            }
+            else
+            {
+                AABB aabb;
+                aabb.merge(leafAABB, nodes[left].aabb);
+                double oldArea = nodes[left].aabb.getSurfaceArea();
+                double newArea = aabb.getSurfaceArea();
+                costLeft = (newArea - oldArea) + inheritanceCost;
+            }
+
+            // Cost of descending to the right.
+            double costRight;
+            if (nodes[right].isLeaf())
+            {
+                AABB aabb;
+                aabb.merge(leafAABB, nodes[right].aabb);
+                costRight = aabb.getSurfaceArea() + inheritanceCost;
+            }
+            else
+            {
+                AABB aabb;
+                aabb.merge(leafAABB, nodes[right].aabb);
+                double oldArea = nodes[right].aabb.getSurfaceArea();
+                double newArea = aabb.getSurfaceArea();
+                costRight = (newArea - oldArea) + inheritanceCost;
+            }
+
+            // Descend according to the minimum cost.
+            if ((cost < costLeft) && (cost < costRight)) break;
+
+            // Descend.
+            if (costLeft < costRight) index = left;
+            else                      index = right;
+        }
+
+        unsigned int sibling = index;
+
+        // Create a new parent.
+        unsigned int oldParent = nodes[sibling].parent;
+        unsigned int newParent = allocateNode();
+        nodes[newParent].parent = oldParent;
+        nodes[newParent].aabb.merge(leafAABB, nodes[sibling].aabb);
+        nodes[newParent].height = nodes[sibling].height + 1;
+
+        // The sibling was not the root.
+        if (oldParent != NULL_NODE)
+        {
+            if (nodes[oldParent].left == sibling) nodes[oldParent].left = newParent;
+            else                                  nodes[oldParent].right = newParent;
+
+            nodes[newParent].left = sibling;
+            nodes[newParent].right = leaf;
+            nodes[sibling].parent = newParent;
+            nodes[leaf].parent = newParent;
+        }
+        // The sibling was the root.
+        else
+        {
+            nodes[newParent].left = sibling;
+            nodes[newParent].right = leaf;
+            nodes[sibling].parent = newParent;
+            nodes[leaf].parent = newParent;
+            root = newParent;
+        }
+
+        // Walk back up the tree fixing heights and AABBs.
+        index = nodes[leaf].parent;
+        while (index != NULL_NODE)
+        {
+            index = balance(index);
+
+            unsigned int left = nodes[index].left;
+            unsigned int right = nodes[index].right;
+
+            assert(left != NULL_NODE);
+            assert(right != NULL_NODE);
+
+            nodes[index].height = 1 + std::max(nodes[left].height, nodes[right].height);
+            nodes[index].aabb.merge(nodes[left].aabb, nodes[right].aabb);
+
+            index = nodes[index].parent;
+        }
+    }
+
+    void Tree::removeLeaf(unsigned int leaf)
+    {
+        if (leaf == root)
+        {
+            root = NULL_NODE;
+            return;
+        }
+
+        unsigned int parent = nodes[leaf].parent;
+        unsigned int grandParent = nodes[parent].parent;
+        unsigned int sibling;
+
+        if (nodes[parent].left == leaf) sibling = nodes[parent].right;
+        else                            sibling = nodes[parent].left;
+
+        // Destroy the parent and connect the sibling to the grandparent.
+        if (grandParent != NULL_NODE)
+        {
+            if (nodes[grandParent].left == parent) nodes[grandParent].left = sibling;
+            else                                   nodes[grandParent].right = sibling;
+
+            nodes[sibling].parent = grandParent;
+            freeNode(parent);
+
+            // Adjust ancestor bounds.
+            unsigned int index = grandParent;
+            while (index != NULL_NODE)
+            {
+                index = balance(index);
+
+                unsigned int left = nodes[index].left;
+                unsigned int right = nodes[index].right;
+
+                nodes[index].aabb.merge(nodes[left].aabb, nodes[right].aabb);
+                nodes[index].height = 1 + std::max(nodes[left].height, nodes[right].height);
+
+                index = nodes[index].parent;
+            }
+        }
+        else
+        {
+            root = sibling;
+            nodes[sibling].parent = NULL_NODE;
+            freeNode(parent);
+        }
+    }
+
+    unsigned int Tree::balance(unsigned int node)
+    {
+        assert(node != NULL_NODE);
+
+        if (nodes[node].isLeaf() || (nodes[node].height < 2))
+            return node;
+
+        unsigned int left = nodes[node].left;
+        unsigned int right = nodes[node].right;
+
+        assert(left < nodeCapacity);
+        assert(right < nodeCapacity);
+
+        int currentBalance = nodes[right].height - nodes[left].height;
+
+        // Rotate right branch up.
+        if (currentBalance > 1)
+        {
+            unsigned int rightLeft = nodes[right].left;
+            unsigned int rightRight = nodes[right].right;
+
+            assert(rightLeft < nodeCapacity);
+            assert(rightRight < nodeCapacity);
+
+            // Swap node and its right-hand child.
+            nodes[right].left = node;
+            nodes[right].parent = nodes[node].parent;
+            nodes[node].parent = right;
+
+            // The node's old parent should now point to its right-hand child.
+            if (nodes[right].parent != NULL_NODE)
+            {
+                if (nodes[nodes[right].parent].left == node) nodes[nodes[right].parent].left = right;
+                else
+                {
+                    assert(nodes[nodes[right].parent].right == node);
+                    nodes[nodes[right].parent].right = right;
+                }
+            }
+            else root = right;
+
+            // Rotate.
+            if (nodes[rightLeft].height > nodes[rightRight].height)
+            {
+                nodes[right].right = rightLeft;
+                nodes[node].right = rightRight;
+                nodes[rightRight].parent = node;
+                nodes[node].aabb.merge(nodes[left].aabb, nodes[rightRight].aabb);
+                nodes[right].aabb.merge(nodes[node].aabb, nodes[rightLeft].aabb);
+
+                nodes[node].height = 1 + std::max(nodes[left].height, nodes[rightRight].height);
+                nodes[right].height = 1 + std::max(nodes[node].height, nodes[rightLeft].height);
+            }
+            else
+            {
+                nodes[right].right = rightRight;
+                nodes[node].right = rightLeft;
+                nodes[rightLeft].parent = node;
+                nodes[node].aabb.merge(nodes[left].aabb, nodes[rightLeft].aabb);
+                nodes[right].aabb.merge(nodes[node].aabb, nodes[rightRight].aabb);
+
+                nodes[node].height = 1 + std::max(nodes[left].height, nodes[rightLeft].height);
+                nodes[right].height = 1 + std::max(nodes[node].height, nodes[rightRight].height);
+            }
+
+            return right;
+        }
+
+        // Rotate left branch up.
+        if (currentBalance < -1)
+        {
+            unsigned int leftLeft = nodes[left].left;
+            unsigned int leftRight = nodes[left].right;
+
+            assert(leftLeft < nodeCapacity);
+            assert(leftRight < nodeCapacity);
+
+            // Swap node and its left-hand child.
+            nodes[left].left = node;
+            nodes[left].parent = nodes[node].parent;
+            nodes[node].parent = left;
+
+            // The node's old parent should now point to its left-hand child.
+            if (nodes[left].parent != NULL_NODE)
+            {
+                if (nodes[nodes[left].parent].left == node) nodes[nodes[left].parent].left = left;
+                else
+                {
+                    assert(nodes[nodes[left].parent].right == node);
+                    nodes[nodes[left].parent].right = left;
+                }
+            }
+            else root = left;
+
+            // Rotate.
+            if (nodes[leftLeft].height > nodes[leftRight].height)
+            {
+                nodes[left].right = leftLeft;
+                nodes[node].left = leftRight;
+                nodes[leftRight].parent = node;
+                nodes[node].aabb.merge(nodes[right].aabb, nodes[leftRight].aabb);
+                nodes[left].aabb.merge(nodes[node].aabb, nodes[leftLeft].aabb);
+
+                nodes[node].height = 1 + std::max(nodes[right].height, nodes[leftRight].height);
+                nodes[left].height = 1 + std::max(nodes[node].height, nodes[leftLeft].height);
+            }
+            else
+            {
+                nodes[left].right = leftRight;
+                nodes[node].left = leftLeft;
+                nodes[leftLeft].parent = node;
+                nodes[node].aabb.merge(nodes[right].aabb, nodes[leftLeft].aabb);
+                nodes[left].aabb.merge(nodes[node].aabb, nodes[leftRight].aabb);
+
+                nodes[node].height = 1 + std::max(nodes[right].height, nodes[leftLeft].height);
+                nodes[left].height = 1 + std::max(nodes[node].height, nodes[leftRight].height);
+            }
+
+            return left;
+        }
+
+        return node;
+    }
+
+    unsigned int Tree::computeHeight() const
+    {
+        return computeHeight(root);
+    }
+
+    unsigned int Tree::computeHeight(unsigned int node) const
+    {
+        assert(node < nodeCapacity);
+
+        if (nodes[node].isLeaf()) return 0;
+
+        unsigned int height1 = computeHeight(nodes[node].left);
+        unsigned int height2 = computeHeight(nodes[node].right);
+
+        return 1 + std::max(height1, height2);
+    }
+
+    unsigned int Tree::getHeight() const
+    {
+        if (root == NULL_NODE) return 0;
+        return nodes[root].height;
+    }
+
+    unsigned int Tree::getNodeCount() const
+    {
+        return nodeCount;
+    }
+
+    unsigned int Tree::computeMaximumBalance() const
+    {
+        unsigned int maxBalance = 0;
+        for (unsigned int i=0; i<nodeCapacity; i++)
+        {
+            if (nodes[i].height <= 1)
+                continue;
+
+            assert(nodes[i].isLeaf() == false);
+
+            unsigned int balance = std::abs(nodes[nodes[i].left].height - nodes[nodes[i].right].height);
+            maxBalance = std::max(maxBalance, balance);
+        }
+
+        return maxBalance;
+    }
+
+    double Tree::computeSurfaceAreaRatio() const
+    {
+        if (root == NULL_NODE) return 0.0;
+
+        double rootArea = nodes[root].aabb.computeSurfaceArea();
+        double totalArea = 0.0;
+
+        for (unsigned int i=0; i<nodeCapacity;i++)
+        {
+            if (nodes[i].height < 0) continue;
+
+            totalArea += nodes[i].aabb.computeSurfaceArea();
+        }
+
+        return totalArea / rootArea;
+    }
+
+    void Tree::validate() const
+    {
+#ifndef NDEBUG
+        validateStructure(root);
+        validateMetrics(root);
+
+        unsigned int freeCount = 0;
+        unsigned int freeIndex = freeList;
+
+        while (freeIndex != NULL_NODE)
+        {
+            assert(freeIndex < nodeCapacity);
+            freeIndex = nodes[freeIndex].next;
+            freeCount++;
+        }
+
+        assert(getHeight() == computeHeight());
+        assert((nodeCount + freeCount) == nodeCapacity);
+#endif
+    }
+
+    void Tree::rebuild()
+    {
+        std::vector<unsigned int> nodeIndices(nodeCount);
+        unsigned int count = 0;
+
+        for (unsigned int i=0;i<nodeCapacity;i++)
+        {
+            // Free node.
+            if (nodes[i].height < 0) continue;
+
+            if (nodes[i].isLeaf())
+            {
+                nodes[i].parent = NULL_NODE;
+                nodeIndices[count] = i;
+                count++;
+            }
+            else freeNode(i);
+        }
+
+        while (count > 1)
+        {
+            double minCost = std::numeric_limits<double>::max();
+            int iMin = -1, jMin = -1;
+
+            for (unsigned int i=0;i<count;i++)
+            {
+                AABB aabbi = nodes[nodeIndices[i]].aabb;
+
+                for (unsigned int j=i+1;j<count;j++)
+                {
+                    AABB aabbj = nodes[nodeIndices[j]].aabb;
+                    AABB aabb;
+                    aabb.merge(aabbi, aabbj);
+                    double cost = aabb.getSurfaceArea();
+
+                    if (cost < minCost)
+                    {
+                        iMin = i;
+                        jMin = j;
+                        minCost = cost;
+                    }
+                }
+            }
+
+            unsigned int index1 = nodeIndices[iMin];
+            unsigned int index2 = nodeIndices[jMin];
+
+            unsigned int parent = allocateNode();
+            nodes[parent].left = index1;
+            nodes[parent].right = index2;
+            nodes[parent].height = 1 + std::max(nodes[index1].height, nodes[index2].height);
+            nodes[parent].aabb.merge(nodes[index1].aabb, nodes[index2].aabb);
+            nodes[parent].parent = NULL_NODE;
+
+            nodes[index1].parent = parent;
+            nodes[index2].parent = parent;
+
+            nodeIndices[jMin] = nodeIndices[count-1];
+            nodeIndices[iMin] = parent;
+            count--;
+        }
+
+        root = nodeIndices[0];
+
+        validate();
+    }
+
+    void Tree::validateStructure(unsigned int node) const
+    {
+        if (node == NULL_NODE) return;
+
+        if (node == root) assert(nodes[node].parent == NULL_NODE);
+
+        unsigned int left = nodes[node].left;
+        unsigned int right = nodes[node].right;
+
+        if (nodes[node].isLeaf())
+        {
+            assert(left == NULL_NODE);
+            assert(right == NULL_NODE);
+            assert(nodes[node].height == 0);
+            return;
+        }
+
+        assert(left < nodeCapacity);
+        assert(right < nodeCapacity);
+
+        assert(nodes[left].parent == node);
+        assert(nodes[right].parent == node);
+
+        validateStructure(left);
+        validateStructure(right);
+    }
+
+    void Tree::validateMetrics(unsigned int node) const
+    {
+        if (node == NULL_NODE) return;
+
+        unsigned int left = nodes[node].left;
+        unsigned int right = nodes[node].right;
+
+        if (nodes[node].isLeaf())
+        {
+            assert(left == NULL_NODE);
+            assert(right == NULL_NODE);
+            assert(nodes[node].height == 0);
+            return;
+        }
+
+        assert(left < nodeCapacity);
+        assert(right < nodeCapacity);
+
+        int height1 = nodes[left].height;
+        int height2 = nodes[right].height;
+        int height = 1 + std::max(height1, height2);
+        (void)height; // Unused variable in Release build
+        assert(nodes[node].height == height);
+
+        AABB aabb;
+        aabb.merge(nodes[left].aabb, nodes[right].aabb);
+
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            assert(std::fabs(aabb.lowerBound[i] - nodes[node].aabb.lowerBound[i]) < 1e-6);
+            assert(std::fabs(aabb.upperBound[i] - nodes[node].aabb.upperBound[i]) < 1e-6);
+        }
+
+        validateMetrics(left);
+        validateMetrics(right);
+    }
+
+    void Tree::periodicBoundaries(std::vector<double>& position)
+    {
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            if (position[i] < 0)
+            {
+                position[i] += boxSize[i];
+            }
+            else
+            {
+                if (position[i] >= boxSize[i])
+                {
+                    position[i] -= boxSize[i];
+                }
+            }
+        }
+    }
+
+    bool Tree::minimumImage(std::vector<double>& separation, std::vector<double>& shift)
+    {
+        bool isShifted = false;
+
+        for (unsigned int i=0;i<dimension;i++)
+        {
+            if (separation[i] < negMinImage[i])
+            {
+                separation[i] += periodicity[i]*boxSize[i];
+                shift[i] = periodicity[i]*boxSize[i];
+                isShifted = true;
+            }
+            else
+            {
+                if (separation[i] >= posMinImage[i])
+                {
+                    separation[i] -= periodicity[i]*boxSize[i];
+                    shift[i] = -periodicity[i]*boxSize[i];
+                    isShifted = true;
+                }
+            }
+        }
+
+        return isShifted;
+    }
+}

--- a/tpe/lib/src/aabb_tree/AABB.h
+++ b/tpe/lib/src/aabb_tree/AABB.h
@@ -1,0 +1,501 @@
+/*
+  Copyright (c) 2009 Erin Catto http://www.box2d.org
+  Copyright (c) 2016-2018 Lester Hedges <lester.hedges+aabbcc@gmail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+  3. This notice may not be removed or altered from any source distribution.
+
+  This code was adapted from parts of the Box2D Physics Engine,
+  http://www.box2d.org
+*/
+
+#ifndef _AABB_H
+#define _AABB_H
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+/// Null node flag.
+const unsigned int NULL_NODE = 0xffffffff;
+
+namespace aabb
+{
+    /*! \brief The axis-aligned bounding box object.
+
+        Axis-aligned bounding boxes (AABBs) store information for the minimum
+        orthorhombic bounding-box for an object. Support is provided for
+        dimensions >= 2. (In 2D the bounding box is either a rectangle,
+        in 3D it is a rectangular prism.)
+
+        Class member functions provide functionality for merging AABB objects
+        and testing overlap with other AABBs.
+     */
+    class AABB
+    {
+    public:
+        /// Constructor.
+        AABB();
+
+        //! Constructor.
+        /*! \param dimension
+                The dimensionality of the system.
+         */
+        explicit AABB(unsigned int);
+
+        //! Constructor.
+        /*! \param lowerBound_
+                The lower bound in each dimension.
+
+            \param upperBound_
+                The upper bound in each dimension.
+         */
+        AABB(const std::vector<double>&, const std::vector<double>&);
+
+        /// Compute the surface area of the box.
+        double computeSurfaceArea() const;
+
+        /// Get the surface area of the box.
+        double getSurfaceArea() const;
+
+        //! Merge two AABBs into this one.
+        /*! \param aabb1
+                A reference to the first AABB.
+
+            \param aabb2
+                A reference to the second AABB.
+         */
+        void merge(const AABB&, const AABB&);
+
+        //! Test whether the AABB is contained within this one.
+        /*! \param aabb
+                A reference to the AABB.
+
+            \return
+                Whether the AABB is fully contained.
+         */
+        bool contains(const AABB&) const;
+
+        //! Test whether the AABB overlaps this one.
+        /*! \param aabb
+                A reference to the AABB.
+
+            \param touchIsOverlap
+                Does touching constitute an overlap?
+
+            \return
+                Whether the AABB overlaps.
+         */
+        bool overlaps(const AABB&, bool touchIsOverlap) const;
+
+        //! Compute the centre of the AABB.
+        /*! \returns
+                The position vector of the AABB centre.
+         */
+        std::vector<double> computeCentre();
+
+        //! Set the dimensionality of the AABB.
+        /*! \param dimension
+                The dimensionality of the system.
+         */
+        void setDimension(unsigned int);
+
+        /// Lower bound of AABB in each dimension.
+        std::vector<double> lowerBound;
+
+        /// Upper bound of AABB in each dimension.
+        std::vector<double> upperBound;
+
+        /// The position of the AABB centre.
+        std::vector<double> centre;
+
+        /// The AABB's surface area.
+        double surfaceArea;
+    };
+
+    /*! \brief A node of the AABB tree.
+
+        Each node of the tree contains an AABB object which corresponds to a
+        particle, or a group of particles, in the simulation box. The AABB
+        objects of individual particles are "fattened" before they are stored
+        to avoid having to continually update and rebalance the tree when
+        displacements are small.
+
+        Nodes are aware of their position within in the tree. The isLeaf member
+        function allows the tree to query whether the node is a leaf, i.e. to
+        determine whether it holds a single particle.
+     */
+    struct Node
+    {
+        /// Constructor.
+        Node();
+
+        /// The fattened axis-aligned bounding box.
+        AABB aabb;
+
+        /// Index of the parent node.
+        unsigned int parent;
+
+        /// Index of the next node.
+        unsigned int next;
+
+        /// Index of the left-hand child.
+        unsigned int left;
+
+        /// Index of the right-hand child.
+        unsigned int right;
+
+        /// Height of the node. This is 0 for a leaf and -1 for a free node.
+        int height;
+
+        /// The index of the particle that the node contains (leaf nodes only).
+        unsigned int particle;
+
+        //! Test whether the node is a leaf.
+        /*! \return
+                Whether the node is a leaf node.
+         */
+        bool isLeaf() const;
+    };
+
+    /*! \brief The dynamic AABB tree.
+
+        The dynamic AABB tree is a hierarchical data structure that can be used
+        to efficiently query overlaps between objects of arbitrary shape and
+        size that lie inside of a simulation box. Support is provided for
+        periodic and non-periodic boxes, as well as boxes with partial
+        periodicity, e.g. periodic along specific axes.
+     */
+    class Tree
+    {
+    public:
+        //! Constructor (non-periodic).
+        /*! \param dimension_
+                The dimensionality of the system.
+
+            \param skinThickness_
+                The skin thickness for fattened AABBs, as a fraction
+                of the AABB base length.
+
+            \param nParticles
+                The number of particles (for fixed particle number systems).
+
+            \param touchIsOverlap
+                Does touching count as overlapping in query operations?
+         */
+        Tree(unsigned int dimension_= 3, double skinThickness_ = 0.05,
+            unsigned int nParticles = 16, bool touchIsOverlap=true);
+
+        //! Constructor (custom periodicity).
+        /*! \param dimension_
+                The dimensionality of the system.
+
+            \param skinThickness_
+                The skin thickness for fattened AABBs, as a fraction
+                of the AABB base length.
+
+            \param periodicity_
+                Whether the system is periodic in each dimension.
+
+            \param boxSize_
+                The size of the simulation box in each dimension.
+
+            \param nParticles
+                The number of particles (for fixed particle number systems).
+
+            \param touchIsOverlap
+                Does touching count as overlapping in query operations?
+         */
+        Tree(unsigned int, double, const std::vector<bool>&, const std::vector<double>&,
+            unsigned int nParticles = 16, bool touchIsOverlap=true);
+
+        //! Set the periodicity of the simulation box.
+        /*! \param periodicity_
+                Whether the system is periodic in each dimension.
+         */
+        void setPeriodicity(const std::vector<bool>&);
+
+        //! Set the size of the simulation box.
+        /*! \param boxSize_
+                The size of the simulation box in each dimension.
+         */
+        void setBoxSize(const std::vector<double>&);
+
+        //! Insert a particle into the tree (point particle).
+        /*! \param index
+                The index of the particle.
+
+            \param position
+                The position vector of the particle.
+
+            \param radius
+                The radius of the particle.
+         */
+        void insertParticle(unsigned int, std::vector<double>&, double);
+
+        //! Insert a particle into the tree (arbitrary shape with bounding box).
+        /*! \param index
+                The index of the particle.
+
+            \param lowerBound
+                The lower bound in each dimension.
+
+            \param upperBound
+                The upper bound in each dimension.
+         */
+        void insertParticle(unsigned int, std::vector<double>&, std::vector<double>&);
+
+        /// Return the number of particles in the tree.
+        unsigned int nParticles();
+
+        //! Remove a particle from the tree.
+        /*! \param particle
+                The particle index (particleMap will be used to map the node).
+         */
+        void removeParticle(unsigned int);
+
+        /// Remove all particles from the tree.
+        void removeAll();
+
+        //! Update the tree if a particle moves outside its fattened AABB.
+        /*! \param particle
+                The particle index (particleMap will be used to map the node).
+
+            \param position
+                The position vector of the particle.
+
+            \param radius
+                The radius of the particle.
+
+            \param alwaysReinsert
+                Always reinsert the particle, even if it's within its old AABB (default:false)
+
+            \return
+                Whether the particle was reinserted.
+         */
+        bool updateParticle(unsigned int, std::vector<double>&, double, bool alwaysReinsert=false);
+
+        //! Update the tree if a particle moves outside its fattened AABB.
+        /*! \param particle
+                The particle index (particleMap will be used to map the node).
+
+            \param lowerBound
+                The lower bound in each dimension.
+
+            \param upperBound
+                The upper bound in each dimension.
+
+            \param alwaysReinsert
+                Always reinsert the particle, even if it's within its old AABB (default: false)
+         */
+        bool updateParticle(unsigned int, std::vector<double>&, std::vector<double>&, bool alwaysReinsert=false);
+
+        //! Query the tree to find candidate interactions for a particle.
+        /*! \param particle
+                The particle index.
+
+            \return particles
+                A vector of particle indices.
+         */
+        std::vector<unsigned int> query(unsigned int);
+
+        //! Query the tree to find candidate interactions for an AABB.
+        /*! \param particle
+                The particle index.
+
+            \param aabb
+                The AABB.
+
+            \return particles
+                A vector of particle indices.
+         */
+        std::vector<unsigned int> query(unsigned int, const AABB&);
+
+        //! Query the tree to find candidate interactions for an AABB.
+        /*! \param aabb
+                The AABB.
+
+            \return particles
+                A vector of particle indices.
+         */
+        std::vector<unsigned int> query(const AABB&);
+
+        //! Get a particle AABB.
+        /*! \param particle
+                The particle index.
+         */
+        const AABB& getAABB(unsigned int);
+
+        //! Get the height of the tree.
+        /*! \return
+                The height of the binary tree.
+         */
+        unsigned int getHeight() const;
+
+        //! Get the number of nodes in the tree.
+        /*! \return
+                The number of nodes in the tree.
+         */
+        unsigned int getNodeCount() const;
+
+        //! Compute the maximum balancance of the tree.
+        /*! \return
+                The maximum difference between the height of two
+                children of a node.
+         */
+        unsigned int computeMaximumBalance() const;
+
+        //! Compute the surface area ratio of the tree.
+        /*! \return
+                The ratio of the sum of the node surface area to the surface
+                area of the root node.
+         */
+        double computeSurfaceAreaRatio() const;
+
+        /// Validate the tree.
+        void validate() const;
+
+        /// Rebuild an optimal tree.
+        void rebuild();
+
+    private:
+        /// The index of the root node.
+        unsigned int root;
+
+        /// The dynamic tree.
+        std::vector<Node> nodes;
+
+        /// The current number of nodes in the tree.
+        unsigned int nodeCount;
+
+        /// The current node capacity.
+        unsigned int nodeCapacity;
+
+        /// The position of node at the top of the free list.
+        unsigned int freeList;
+
+        /// The dimensionality of the system.
+        unsigned int dimension;
+
+        /// Whether the system is periodic along at least one axis.
+        bool isPeriodic;
+
+        /// The skin thickness of the fattened AABBs, as a fraction of the AABB base length.
+        double skinThickness;
+
+        /// Whether the system is periodic along each axis.
+        std::vector<bool> periodicity;
+
+        /// The size of the system in each dimension.
+        std::vector<double> boxSize;
+
+        /// The position of the negative minimum image.
+        std::vector<double> negMinImage;
+
+        /// The position of the positive minimum image.
+        std::vector<double> posMinImage;
+
+        /// A map between particle and node indices.
+        std::unordered_map<unsigned int, unsigned int> particleMap;
+
+        /// Does touching count as overlapping in tree queries?
+        bool touchIsOverlap;
+
+        //! Allocate a new node.
+        /*! \return
+                The index of the allocated node.
+         */
+        unsigned int allocateNode();
+
+        //! Free an existing node.
+        /*! \param node
+                The index of the node to be freed.
+         */
+        void freeNode(unsigned int);
+
+        //! Insert a leaf into the tree.
+        /*! \param leaf
+                The index of the leaf node.
+         */
+        void insertLeaf(unsigned int);
+
+        //! Remove a leaf from the tree.
+        /*! \param leaf
+                The index of the leaf node.
+         */
+        void removeLeaf(unsigned int);
+
+        //! Balance the tree.
+        /*! \param node
+                The index of the node.
+         */
+        unsigned int balance(unsigned int);
+
+        //! Compute the height of the tree.
+        /*! \return
+                The height of the entire tree.
+         */
+        unsigned int computeHeight() const;
+
+        //! Compute the height of a sub-tree.
+        /*! \param node
+                The index of the root node.
+
+            \return
+                The height of the sub-tree.
+         */
+        unsigned int computeHeight(unsigned int) const;
+
+        //! Assert that the sub-tree has a valid structure.
+        /*! \param node
+                The index of the root node.
+         */
+        void validateStructure(unsigned int) const;
+
+        //! Assert that the sub-tree has valid metrics.
+        /*! \param node
+                The index of the root node.
+         */
+        void validateMetrics(unsigned int) const;
+
+        //! Apply periodic boundary conditions.
+        /* \param position
+                The position vector.
+         */
+        void periodicBoundaries(std::vector<double>&);
+
+        //! Compute minimum image separation.
+        /*! \param separation
+                The separation vector.
+
+            \param shift
+                The shift vector.
+
+            \return
+                Whether a periodic shift has been applied.
+         */
+        bool minimumImage(std::vector<double>&, std::vector<double>&);
+    };
+}
+
+#endif /* _AABB_H */

--- a/tpe/lib/src/aabb_tree/LICENSE
+++ b/tpe/lib/src/aabb_tree/LICENSE
@@ -1,0 +1,24 @@
+The zlib/libpng License (Zlib)
+
+Copyright (c) 2009 Erin Catto http://www.box2d.org
+Copyright (c) 2016 Lester Hedges <lester.hedges+aabbcc@gmail.com>
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+This code was adapted from parts of the Box2D Physics Engine, http://www.box2d.org


### PR DESCRIPTION
Initial performance tests revealed a bottleneck in TPE's naive collision detection algorithm. This PR integrates an AABB tree from a third party library to help with collision detection by checking for overlaps between objects' axis aligned bounding boxes.

I tested 3 AABB tree libraries and [the one](https://github.com/lohedges/aabbcc) chosen has the best performance while providing more features like tree balancing.

Here're graphs comparing the `World::Step` performance in ign-gazebo's [shapes_population.sdf](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo3/examples/worlds/shapes_population.sdf) world that consists of 3000 models.

TPE before (~779ms) :

![tpe_step_before](https://user-images.githubusercontent.com/4000684/90716433-d024d000-e261-11ea-97bb-9b43b2e8501e.png)

TPE after using AABB tree (~17ms)

![tpe_step_aabb_tree](https://user-images.githubusercontent.com/4000684/90716450-d87d0b00-e261-11ea-99c8-0fcf56282957.png)

Dart (~155ms):

![dart_step](https://user-images.githubusercontent.com/4000684/90716522-019d9b80-e262-11ea-9277-bc0ba140b64a.png)


The performance of TPE with AABB tree is roughly 45x faster than before and 9x faster than Dart
 