### PR TITLE
Fix code snippet rendering

### DIFF
--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -39,45 +39,39 @@ Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on w
 **Build from source**
 
 1. Run the following to install dependencies
-
-    ```{.sh}
-    sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
-    sudo apt-get build-dep -y ignition-physics<#>-dev
-    ```
-
-    Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
+  ```{.sh}
+  sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main"
+  sudo apt-get build-dep -y ignition-physics<#>-dev
+  ```
+  Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
 
 
 2. Use gcc-8:
-
-    ```
-    sudo apt update
-    sudo apt-get -y install g++-8
-    sudo update-alternatives --install \
-      /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
-      --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-      --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-    ```
+  ```
+  sudo apt update
+  sudo apt-get -y install g++-8
+  sudo update-alternatives --install \
+    /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+  ```
 
 3. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-physics -b ign-physics<#>
-    ```
-    Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
+  ```
+  git clone https://github.com/ignitionrobotics/ign-physics -b ign-physics<#>
+  ```
+  Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
 
 
 4. Configure and build
-
-    ```
-    cd ign-physics; mkdir build; cd build; cmake ..; make
-    ```
+  ```
+  cd ign-physics; mkdir build; cd build; cmake ..; make
+  ```
 
 5. Optionally, install Ignition Physics
-
-    ```
-    sudo make install
-    ```
+  ```
+  sudo make install
+  ```
 
 ## macOS
 


### PR DESCRIPTION
Code snippets indented by 4 spaces were being treated as preformatted text. Just removing the indent puts the code snippet at the wrong indentation level. The solution is to remove the extra line between a bullet point and the code snippet.
### Before:
![image](https://user-images.githubusercontent.com/206116/94716867-241cdd00-0315-11eb-95e6-a4acebabbb1a.png)

### After:
![image](https://user-images.githubusercontent.com/206116/94716987-4f9fc780-0315-11eb-9cf6-5878b664ccf7.png)

