### PR TITLE
Fix CONFIG arg in ign_find_package(DART) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ ign_find_package(DART
     collision-ode
     utils
     utils-urdf
-  CONFIG
+  EXTRA_ARGS CONFIG
   VERSION 6.9
   REQUIRED_BY dartsim
   PKGCONFIG dart


### PR DESCRIPTION
The `CONFIG` argument to `find_package` does not have a [corresponding argument in `ign_find_package`](https://github.com/ignitionrobotics/ign-cmake/blob/ignition-cmake2_2.5.0/cmake/IgnUtils.cmake#L3-L15), though it happens to work in our `ign_find_package(DART)` call by accident since it gets treated as a component. It can be properly passed through as an `EXTRA_ARGS` parameter.

To reproduce the bug, change the order of the `ign_find_package` parameters with the following patch and observe that it gives a cmake warning for unrecognized arguments:

~~~
diff --git a/CMakeLists.txt b/CMakeLists.txt
index a732852..1c384ac 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,11 +61,11 @@ ign_find_package(sdformat10 REQUIRED_BY sdf dartsim tpe)
 #--------------------------------------
 # Find dartsim for the dartsim plugin wrapper
 ign_find_package(DART
+  CONFIG
   COMPONENTS
     collision-ode
     utils
     utils-urdf
-  CONFIG
   VERSION 6.9
   REQUIRED_BY dartsim
   PKGCONFIG dart
~~~

~~~
CMake Warning (dev) at /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:1758 (message):
  

  The build script has specified some unrecognized arguments for
  ign_find_package(~):

  CONFIG

  Either the script has a typo, or it is using an unexpected version of
  ign-cmake.  The version of ign-cmake currently being used is 2.4.0

Call Stack (most recent call first):
  /usr/share/cmake/ignition-cmake2/cmake2/IgnUtils.cmake:146 (_ign_cmake_parse_arguments)
  CMakeLists.txt:63 (ign_find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
~~~

I've filed https://github.com/ignitionrobotics/ign-cmake/issues/114 to track adding `CONFIG` as a supported option to `ign_find_package`, but let's just fix it for now.