### PR TITLE
Backport #119 to ign-physics2: Fix CONFIG arg in ign_find_package(DART) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ ign_find_package(DART
     collision-ode
     utils
     utils-urdf
-  CONFIG
+  EXTRA_ARGS CONFIG
   VERSION 6.9
   REQUIRED_BY dartsim
   PKGCONFIG dart


### PR DESCRIPTION
Backport #119 to ign-physics2. Use rebase and merge.

Original description:

Fix CONFIG arg in ign_find_package(DART) call (#119)

The CONFIG argument to find_package does not have a corresponding
argument in ign_find_package, though it happens to work in our
ign_find_package(DART) call by accident since it gets treated
as a component. It can be properly passed through as an
EXTRA_ARGS parameter.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>