### PR TITLE
Backport #119 to ign-physics1: Fix CONFIG arg in ign_find_package(DART) call (#119)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ ign_find_package(DART
     collision-ode
     utils
     utils-urdf
-  CONFIG
+  EXTRA_ARGS CONFIG
   VERSION 6.10.0
   REQUIRED_BY dartsim
   PKGCONFIG dart


### PR DESCRIPTION
Backport #119 to ign-physics1. Use rebase and merge.

Original descriptions:

Fix CONFIG arg in ign_find_package(DART) call (#119)

The CONFIG argument to find_package does not have a corresponding
argument in ign_find_package, though it happens to work in our
ign_find_package(DART) call by accident since it gets treated
as a component. It can be properly passed through as an
EXTRA_ARGS parameter.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>