### PR TITLE
Fix getting model bounding box in world frame in TPE

### DIFF
--- a/tpe/plugin/src/KinematicsFeatures.cc
+++ b/tpe/plugin/src/KinematicsFeatures.cc
@@ -39,9 +39,8 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
     return data;
   }
 
+  // check if it's model
   auto modelIt = this->models.find(_id.ID());
-  auto linkIt = this->links.find(_id.ID());
-
   if (modelIt != this->models.end())
   {
     auto model = modelIt->second->model;
@@ -49,15 +48,30 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
     data.linearVelocity = math::eigen3::convert(model->GetLinearVelocity());
     data.angularVelocity = math::eigen3::convert(model->GetAngularVelocity());
   }
-  else if (linkIt != this->links.end())
-  {
-    auto link = linkIt->second->link;
-    data.pose = math::eigen3::convert(link->GetWorldPose());
-  }
   else
   {
-    ignwarn << "Entity with id ["
-      << _id.ID() << "] is not found" << std::endl;
+    // check if it's link
+    auto linkIt = this->links.find(_id.ID());
+    if (linkIt != this->links.end())
+    {
+      auto link = linkIt->second->link;
+      data.pose = math::eigen3::convert(link->GetWorldPose());
+    }
+    else
+    {
+      // check if it's collision
+      auto colIt = this->collisions.find(_id.ID());
+      if (colIt != this->collisions.end())
+      {
+        auto collision = colIt->second->collision;
+        data.pose = math::eigen3::convert(collision->GetWorldPose());
+      }
+      else
+      {
+        ignwarn << "Entity with id ["
+          << _id.ID() << "] is not found" << std::endl;
+      }
+    }
   }
   return data;
 }


### PR DESCRIPTION
By default the `GetAxisAlignedBoundingBox` feature requests a model's bounding box in world frame, and computes it by merging all child links and shapes' bounding boxes in the requested frame. The problem was that we did not have support for getting frame data for shapes in the KinematicsFeatures so the bounding box returned was incorrect. The PR adds an extra check in the collision (shape) list when searching for frame data.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>