### PR TITLE
⬆️  3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-physics3 VERSION 3.0.0)
+project(ignition-physics3 VERSION 3.1.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,26 @@
 
 ### Ignition Physics 3.x.x (20XX-XX-XX)
 
+### Ignition Physics 3.1.0 (2020-10-18)
+
+1. Support for slip compliance in the dartsim-plugin.
+    * [Pull request 56](https://github.com/ignitionrobotics/ign-physics/pull/56)
+
+1. Enforce joint effort limit in dartsim-plugin
+    * [Pull request 74](https://github.com/ignitionrobotics/ign-physics/pull/74)
+
+1. Support nested models in TPE
+    * [Pull request 86](https://github.com/ignitionrobotics/ign-physics/pull/86)
+
+1. Fix CONFIG arg in ign_find_package(DART) call
+    * [Pull request 119](https://github.com/ignitionrobotics/ign-physics/pull/119)
+
+1. Fix getting model bounding box in world frame in TPE
+    * [Pull request 127](https://github.com/ignitionrobotics/ign-physics/pull/127)
+
+1. Improve fork experience
+    * [Pull request 130](https://github.com/ignitionrobotics/ign-physics/pull/130)
+
 ### Ignition Physics 3.0.0 (2020-09-30)
 
 1. Upgrade to libsdformat10


### PR DESCRIPTION
Prepare for 3.1.0 release.

This is needed to unblock https://github.com/ignitionrobotics/ign-gazebo/pull/410/

Comparison to 3.0.0: https://github.com/ignitionrobotics/ign-physics/compare/ignition-physics3_3.0.0...ign-physics3