### PR TITLE
Ignore invalid joint commands

### DIFF
--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -67,22 +67,57 @@ Pose3d JointFeatures::GetJointTransform(const Identity &_id) const
 void JointFeatures::SetJointPosition(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
-  this->ReferenceInterface<JointInfo>(_id)->joint->setPosition(_dof, _value);
+  auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+
+  // Take extra care that the value is finite. A nan can cause the DART
+  // constraint solver to fail, which will in turn either cause a crash or
+  // collisions to fail
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Invalid joint position value [" << _value << "] set on joint ["
+           << joint->getName() << " DOF " << _dof
+           << "]. The value will be ignored\n";
+    return;
+  }
+  joint->setPosition(_dof, _value);
 }
 
 /////////////////////////////////////////////////
 void JointFeatures::SetJointVelocity(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
-  this->ReferenceInterface<JointInfo>(_id)->joint->setVelocity(_dof, _value);
+  auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+
+  // Take extra care that the value is finite. A nan can cause the DART
+  // constraint solver to fail, which will in turn either cause a crash or
+  // collisions to fail
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Invalid joint velocity value [" << _value << "] set on joint ["
+           << joint->getName() << " DOF " << _dof
+           << "]. The value will be ignored\n";
+    return;
+  }
+  joint->setVelocity(_dof, _value);
 }
 
 /////////////////////////////////////////////////
 void JointFeatures::SetJointAcceleration(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
-  this->ReferenceInterface<JointInfo>(_id)->joint->setAcceleration(_dof,
-                                                                   _value);
+  auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+
+  // Take extra care that the value is finite. A nan can cause the DART
+  // constraint solver to fail, which will in turn either cause a crash or
+  // collisions to fail
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Invalid joint acceleration value [" << _value
+           << "] set on joint [" << joint->getName() << " DOF " << _dof
+           << "]. The value will be ignored\n";
+    return;
+  }
+  joint->setAcceleration(_dof, _value);
 }
 
 /////////////////////////////////////////////////
@@ -90,6 +125,17 @@ void JointFeatures::SetJointForce(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
   auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+
+  // Take extra care that the value is finite. A nan can cause the DART
+  // constraint solver to fail, which will in turn either cause a crash or
+  // collisions to fail
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Invalid joint force value [" << _value << "] set on joint ["
+           << joint->getName() << " DOF " << _dof
+           << "]. The value will be ignored\n";
+    return;
+  }
   if (joint->getActuatorType() != dart::dynamics::Joint::FORCE)
   {
     joint->setActuatorType(dart::dynamics::Joint::FORCE);
@@ -103,9 +149,9 @@ void JointFeatures::SetJointVelocityCommand(
 {
   auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
 
-  // Take extra care that the value is finite since this value will be used in
-  // DART's constraint solver. A nan will cause the solver to fail, which will
-  // in turn cause collisions to fail
+  // Take extra care that the value is finite. A nan can cause the DART
+  // constraint solver to fail, which will in turn either cause a crash or
+  // collisions to fail
   if (!std::isfinite(_value))
   {
     ignerr << "Invalid joint velocity value [" << _value

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -102,6 +102,17 @@ void JointFeatures::SetJointVelocityCommand(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
   auto joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+
+  // Take extra care that the value is finite since this value will be used in
+  // DART's constraint solver. A nan will cause the solver to fail, which will
+  // in turn cause collisions to fail
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Invalid joint velocity value [" << _value
+           << "] commanded on joint [" << joint->getName() << " DOF " << _dof
+           << "]. The command will be ignored\n";
+    return;
+  }
   if (joint->getActuatorType() != dart::dynamics::Joint::SERVO)
   {
     joint->setActuatorType(dart::dynamics::Joint::SERVO);

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -142,8 +142,9 @@ TEST_F(JointFeaturesFixture, JointSetCommand)
   }
 
   // Check that invalid velocity commands don't cause collisions to fail
-  const dart::dynamics::BodyNodePtr dartBaseLink = skeleton->getBodyNode("base");
-  ASSERT_NE(nullptr, dartBaseLink );
+  const dart::dynamics::BodyNodePtr dartBaseLink =
+      skeleton->getBodyNode("base");
+  ASSERT_NE(nullptr, dartBaseLink);
   for (std::size_t i = 0; i < 1000; ++i)
   {
     joint->SetVelocityCommand(0, std::numeric_limits<double>::quiet_NaN());

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -59,6 +59,7 @@ using TestFeatureList = ignition::physics::FeatureList<
   physics::GetBasicJointState,
   physics::GetEntities,
   physics::RevoluteJointCast,
+  physics::SetBasicJointState,
   physics::SetJointVelocityCommandFeature,
   physics::sdf::ConstructSdfModel,
   physics::sdf::ConstructSdfWorld
@@ -106,6 +107,8 @@ TEST_F(JointFeaturesFixture, JointSetCommand)
       dartWorld->getSkeleton(modelName);
   ASSERT_NE(nullptr, skeleton);
 
+  const auto *dartBaseLink = skeleton->getBodyNode("base");
+  ASSERT_NE(nullptr, dartBaseLink);
   const auto *dartJoint = skeleton->getJoint(jointName);
 
   // Default actuatore type
@@ -119,6 +122,15 @@ TEST_F(JointFeaturesFixture, JointSetCommand)
   // Expect negative joint velocity after 1 step without joint command
   world->Step(output, state, input);
   EXPECT_LT(joint->GetVelocity(0), 0.0);
+
+  // Check that invalid velocity commands don't cause collisions to fail
+  for (std::size_t i = 0; i < 1000; ++i)
+  {
+    joint->SetForce(0, std::numeric_limits<double>::quiet_NaN());
+    // expect the position of the pendulum to stay aabove ground
+    world->Step(output, state, input);
+    EXPECT_NEAR(0.0, dartBaseLink->getWorldTransform().translation().z(), 1e-3);
+  }
 
   joint->SetVelocityCommand(0, 1);
   world->Step(output, state, input);
@@ -142,9 +154,6 @@ TEST_F(JointFeaturesFixture, JointSetCommand)
   }
 
   // Check that invalid velocity commands don't cause collisions to fail
-  const dart::dynamics::BodyNodePtr dartBaseLink =
-      skeleton->getBodyNode("base");
-  ASSERT_NE(nullptr, dartBaseLink);
   for (std::size_t i = 0; i < 1000; ++i)
   {
     joint->SetVelocityCommand(0, std::numeric_limits<double>::quiet_NaN());

--- a/dartsim/src/JointFeatures_TEST.cc
+++ b/dartsim/src/JointFeatures_TEST.cc
@@ -40,6 +40,7 @@
 #include <ignition/physics/sdf/ConstructModel.hh>
 #include <ignition/physics/sdf/ConstructWorld.hh>
 
+#include <limits>
 #include <sdf/Model.hh>
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
@@ -138,6 +139,17 @@ TEST_F(JointFeaturesFixture, JointSetCommand)
     // expect joint to freeze in subsequent steps without SetVelocityCommand
     world->Step(output, state, input);
     EXPECT_NEAR(0.0, joint->GetVelocity(0), 1e-6);
+  }
+
+  // Check that invalid velocity commands don't cause collisions to fail
+  const dart::dynamics::BodyNodePtr dartBaseLink = skeleton->getBodyNode("base");
+  ASSERT_NE(nullptr, dartBaseLink );
+  for (std::size_t i = 0; i < 1000; ++i)
+  {
+    joint->SetVelocityCommand(0, std::numeric_limits<double>::quiet_NaN());
+    // expect the position of the pendulum to stay aabove ground
+    world->Step(output, state, input);
+    EXPECT_NEAR(0.0, dartBaseLink->getWorldTransform().translation().z(), 1e-3);
   }
 }
 


### PR DESCRIPTION
Robots falling through the floor were reported in https://github.com/osrf/subt/issues/675. This was caused by an input joint velocity command of `nan`  being passed to `JointFeatures::SetJointVelocityCommand` via ign-gazebo's DiffDrive system. In DART, Joint velocity commands are handled by the constraint solver, which also handles collisions, so it makes sense that the robot falls through when the solver fails. The solution here is to ignore `nan` values in `JointFeatures::SetJointVelocityCommand`.

I have taken the opportunity to ignore invalid values in other `JointFeatures::SetJoint*` commands as well.