### PR TITLE
Add restitution coefficient support for bouncing

### DIFF
--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include <dart/config.hpp>
 #include <dart/collision/ode/OdeCollisionDetector.hpp>

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -571,6 +571,16 @@ Identity SDFFeatures::ConstructSdfCollision(
       math::Vector3d fdir1 = odeFriction->Get<math::Vector3d>("fdir1");
       aspect->setFirstFrictionDirection(math::eigen3::convert(fdir1));
     }
+
+    const auto &surfaceBounce = _collision.Element()
+                                    ->GetElement("surface")
+                                    ->GetElement("bounce");
+
+    if (surfaceBounce->HasElement("restitution_coefficient"))
+    {
+      aspect->setRestitutionCoeff(
+          surfaceBounce->Get<double>("restitution_coefficient"));
+    }
 #else
     // We are setting the friction coefficient of a collision element
     // to be the coefficient for the whole link. If there are multiple collision

--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -590,6 +590,15 @@ Identity SDFFeatures::ConstructSdfCollision(
     // TODO(addisu) Assign the coefficient to the shape node when support is
     // added in DART.
     bn->setFrictionCoeff(odeFriction->Get<double>("mu"));
+    const auto &surfaceBounce = _collision.Element()
+                                    ->GetElement("surface")
+                                    ->GetElement("bounce");
+
+    if (surfaceBounce->HasElement("restitution_coefficient"))
+    {
+      bn->setRestitutionCoeff(
+          surfaceBounce->Get<double>("restitution_coefficient"));
+    }
 #endif
     // TODO(anyone) add category_bitmask as well
     const auto bitmaskElement = _collision.Element()

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -158,20 +158,26 @@ TEST(SDFFeatures_TEST, CheckDartsimData)
     EXPECT_DOUBLE_EQ(0.0, axis[2]);
   }
 
-  const dart::dynamics::SkeletonPtr freeBody =
+  {
+    const dart::dynamics::SkeletonPtr freeBody =
       dartWorld->getSkeleton("free_body");
-  ASSERT_NE(nullptr, freeBody);
-  ASSERT_EQ(1u, freeBody->getNumBodyNodes());
-  const dart::dynamics::BodyNode *bn = freeBody->getBodyNode(0);
-  ASSERT_NE(nullptr, bn);
+    ASSERT_NE(nullptr, freeBody);
+    ASSERT_EQ(1u, freeBody->getNumBodyNodes());
+    const dart::dynamics::BodyNode *bn = freeBody->getBodyNode(0);
+    ASSERT_NE(nullptr, bn);
 
-  EXPECT_TRUE(dynamic_cast<const dart::dynamics::FreeJoint*>(
-                bn->getParentJoint()));
+    EXPECT_TRUE(dynamic_cast<const dart::dynamics::FreeJoint*>(
+          bn->getParentJoint()));
 
-  const Eigen::Vector3d translation = bn->getTransform().translation();
-  EXPECT_DOUBLE_EQ(0.0, translation[0]);
-  EXPECT_DOUBLE_EQ(10.0, translation[1]);
-  EXPECT_DOUBLE_EQ(10.0, translation[2]);
+    const Eigen::Vector3d translation = bn->getTransform().translation();
+    EXPECT_DOUBLE_EQ(0.0, translation[0]);
+    EXPECT_DOUBLE_EQ(10.0, translation[1]);
+    EXPECT_DOUBLE_EQ(10.0, translation[2]);
+
+    const dart::dynamics::ShapeNode *collision1 = bn->getShapeNode(0);
+    auto aspect = collision1->getDynamicsAspect();
+    EXPECT_EQ(0.8, aspect->getRestitutionCoeff());
+  }
 
   const dart::dynamics::SkeletonPtr screwJointTest =
       dartWorld->getSkeleton("screw_joint_test");

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -174,9 +174,13 @@ TEST(SDFFeatures_TEST, CheckDartsimData)
     EXPECT_DOUBLE_EQ(10.0, translation[1]);
     EXPECT_DOUBLE_EQ(10.0, translation[2]);
 
+#if DART_VERSION_AT_LEAST(6, 10, 0)
     const dart::dynamics::ShapeNode *collision1 = bn->getShapeNode(0);
     auto aspect = collision1->getDynamicsAspect();
     EXPECT_DOUBLE_EQ(0.8, aspect->getRestitutionCoeff());
+#else
+    EXPECT_DOUBLE_EQ(0.8, bn->getRestitutionCoeff());
+  #endif
   }
 
   const dart::dynamics::SkeletonPtr screwJointTest =

--- a/dartsim/src/SDFFeatures_TEST.cc
+++ b/dartsim/src/SDFFeatures_TEST.cc
@@ -176,7 +176,7 @@ TEST(SDFFeatures_TEST, CheckDartsimData)
 
     const dart::dynamics::ShapeNode *collision1 = bn->getShapeNode(0);
     auto aspect = collision1->getDynamicsAspect();
-    EXPECT_EQ(0.8, aspect->getRestitutionCoeff());
+    EXPECT_DOUBLE_EQ(0.8, aspect->getRestitutionCoeff());
   }
 
   const dart::dynamics::SkeletonPtr screwJointTest =

--- a/dartsim/worlds/test.world
+++ b/dartsim/worlds/test.world
@@ -246,6 +246,18 @@
       <pose>0.0  10.0  10.0  0.0  0.0  0.0</pose>
       <link name="link">
         <pose>0.0  0.0  0.0  0.0  0.0  0.0</pose>
+        <collision name="collision1">
+          <geometry>
+            <sphere>
+              <radius>1.0</radius>
+            </sphere>
+          </geometry>
+          <surface>
+            <bounce>
+              <restitution_coefficient>0.8</restitution_coefficient>
+            </bounce>
+          </surface>
+        </collision>
       </link>
     </model>
 


### PR DESCRIPTION
This PR adds the support of simulating bouncing using [`//collision/surface/bounce/restitution_coefficient`](http://sdformat.org/spec?ver=1.7&elem=collision#surface_bounce). It calls the methods introduced in https://github.com/dartsim/dart/pull/1369.

This is the resulting behaviour simulating 11 spheres with a different restitution coefficient and setting the coefficient of the ground to `1.0`:

![out](https://user-images.githubusercontent.com/469199/96753808-afe3cf80-13d0-11eb-9987-6a10e62fc7c5.gif)

<details>

<summary>Script (requires third party libraries)</summary>

```py
import numpy as np
from dataclasses import dataclass
from gym_ignition.utils import misc
from scenario import core as scenario_core
from scenario import gazebo as scenario_gazebo
from gym_ignition.utils.scenario import init_gazebo_sim


@dataclass
class SphereURDF:

    mass: float = 5.0
    radius: float = 0.1
    restitution: float = 0

    def urdf(self) -> str:

        i = 2.0 / 5 * self.mass * self.radius * self.radius
        urdf = f"""
            <robot name="sphere_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
                <link name="sphere">
                    <inertial>
                      <origin rpy="0 0 0" xyz="0 0 0"/>
                      <mass value="{self.mass}"/>
                      <inertia ixx="{i}" ixy="0" ixz="0" iyy="{i}" iyz="0" izz="{i}"/>
                    </inertial>
                    <visual>
                      <geometry>
                        <sphere radius="{self.radius}"/>
                      </geometry>
                      <origin rpy="0 0 0" xyz="0 0 0"/>
                    </visual>
                    <collision>
                      <geometry>
                        <sphere radius="{self.radius}"/>
                      </geometry>
                      <origin rpy="0 0 0" xyz="0 0 0"/>
                    </collision>
                </link>
                <gazebo reference="sphere">
                  <collision><surface><bounce>
                    <restitution_coefficient>{self.restitution}</restitution_coefficient>
                  </bounce></surface></collision>
                </gazebo>
            </robot>
            """

        return urdf


# Set the verbosity
scenario_gazebo.set_verbosity(scenario_gazebo.Verbosity_debug)

# Get the default simulator and the default empty world
gazebo, world = init_gazebo_sim()

# Show the GUI
import time
gazebo.gui()
gazebo.run(paused=True)
time.sleep(3)

for restitution in np.linspace(start=0, stop=1.0, num=11):

    # Create a tmp file with the urdf
    sphere_urdf = SphereURDF(restitution=restitution).urdf()
    sphere_urdf_file = misc.string_to_file(sphere_urdf)

    # Insert the sphere
    pose = scenario_core.Pose_identity()
    pose.position = [0, restitution * 3, 1.0]
    assert world.to_gazebo().insert_model(sphere_urdf_file, pose, f"sphere_{restitution}")

gazebo.run(paused=True)

for _ in range(10_000):
    gazebo.run()

time.sleep(5)
gazebo.close()

```

</details>

This PR fills one of the gaps described in https://www.allisonthackston.com/articles/ignition_vs_gazebo.html.