### PR TITLE
[dart] Compute Inverse Dynamics for all skeletons to populate joint forces

### DIFF
--- a/dartsim/src/Base.hh
+++ b/dartsim/src/Base.hh
@@ -338,6 +338,7 @@ class Base : public Implements3d<FeatureList<Feature>>
       this->links.RemoveEntity(bn);
     }
     this->models.RemoveEntity(skel);
+    this->skeletonsWithInverseDynamics.erase(skel);
     world->removeSkeleton(skel);
   }
 
@@ -347,6 +348,7 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: EntityStorage<JointInfoPtr, const DartJoint*> joints;
   public: EntityStorage<ShapeInfoPtr, const DartShapeNode*> shapes;
   public: std::unordered_map<std::size_t, const dart::dynamics::Frame*> frames;
+  public: std::set<dart::dynamics::SkeletonPtr> skeletonsWithInverseDynamics;
 };
 
 }

--- a/dartsim/src/JointFeatures.cc
+++ b/dartsim/src/JointFeatures.cc
@@ -53,6 +53,16 @@ double JointFeatures::GetJointAcceleration(
 double JointFeatures::GetJointForce(
     const Identity &_id, const std::size_t _dof) const
 {
+  // Enable the computation of Inverse Dynamics on this skeleton
+  const auto &joint = this->ReferenceInterface<JointInfo>(_id)->joint;
+  if (this->skeletonsWithInverseDynamics.find(joint->getSkeleton()) ==
+      this->skeletonsWithInverseDynamics.end())
+  {
+    auto* thisNonConst = const_cast<JointFeatures*>(this);
+    thisNonConst->skeletonsWithInverseDynamics.insert(joint->getSkeleton());
+    joint->getSkeleton()->computeInverseDynamics();
+  }
+
   return this->ReferenceInterface<JointInfo>(_id)->joint->getForce(_dof);
 }
 

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -53,6 +53,14 @@ void SimulationFeatures::WorldForwardStep(
   // TODO(MXG): Parse input
   world->step();
   // TODO(MXG): Fill in output and state
+
+  // Compute ID to populate the joint forces
+  for (size_t i = 0; i < world->getNumSkeletons(); ++i) {
+    world->getSkeleton(i)->computeInverseDynamics(
+      /*_withExternalForces=*/true,
+      /*_withDampingForces=*/true,
+      /*_withSpringForces=*/true);
+  }
 }
 
 std::vector<SimulationFeatures::ContactInternal>

--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -54,12 +54,12 @@ void SimulationFeatures::WorldForwardStep(
   world->step();
   // TODO(MXG): Fill in output and state
 
-  // Compute ID to populate the joint forces
-  for (size_t i = 0; i < world->getNumSkeletons(); ++i) {
-    world->getSkeleton(i)->computeInverseDynamics(
-      /*_withExternalForces=*/true,
-      /*_withDampingForces=*/true,
-      /*_withSpringForces=*/true);
+  for (auto &skeleton: this->skeletonsWithInverseDynamics)
+  {
+    skeleton->computeInverseDynamics(
+        /*_withExternalForces=*/true,
+        /*_withDampingForces=*/true,
+        /*_withSpringForces=*/true);
   }
 }
 


### PR DESCRIPTION
From @azeey's https://github.com/ignitionrobotics/ign-physics/issues/124#issuecomment-707824160:

> I didn't know that we needed `Skeleton::computeInverseDynamics`, but it makes sense since step clears all forces. Another option might be to call `step(false)` first, collect all the joint forces into `ignition::physics::ForwardStep::Output` and then clear the forces.

I'm not sure I got what you meant in the alternative option. Contrarily to what I initially proposed in https://github.com/ignitionrobotics/ign-physics/issues/124#issue-718027724, this PR computes ID for all simulated models in the `SimulationFeatures::WorldForwardStep` function. This prevents computing ID every time `JointFeatures::GetJointForce` is called.

Fixes https://github.com/ignitionrobotics/ign-physics/issues/124.
