### PR TITLE
dartsim-plugin windows build fixes

### DIFF
--- a/dartsim/CMakeLists.txt
+++ b/dartsim/CMakeLists.txt
@@ -7,6 +7,10 @@ ign_add_component(dartsim INTERFACE
 
 target_link_libraries(${features} INTERFACE ${DART_LIBRARIES})
 target_include_directories(${features} SYSTEM INTERFACE ${DART_INCLUDE_DIRS})
+if (MSVC)
+  # needed by DART, see https://github.com/dartsim/dart/issues/753
+  target_compile_options(${features} INTERFACE "/permissive-")
+endif()
 
 install(
   DIRECTORY include/
@@ -42,11 +46,15 @@ install(TARGETS ${dartsim_plugin} DESTINATION ${IGNITION_PHYSICS_ENGINE_INSTALL_
 set(versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${dartsim_plugin}${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 if (WIN32)
-  # create_symlink requires cmake 3.13 on windows
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+  # disable MSVC inherit via dominance warning
+  target_compile_options(${dartsim_plugin} PUBLIC "/wd4250")
+  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
+      ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
+      ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
+else()
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR})
 endif()
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR})
 
 # Testing
 ign_build_tests(

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -24,4 +24,10 @@ if (DART_FOUND)
   target_link_libraries(MockDoublePendulum PUBLIC ${DART_LIBRARIES})
   target_compile_definitions(MockDoublePendulum PRIVATE
     "IGNITION_PHYSICS_RESOURCE_DIR=\"${IGNITION_PHYSICS_RESOURCE_DIR}\"")
+  if (MSVC)
+    # needed by DART, see https://github.com/dartsim/dart/issues/753
+    target_compile_options(MockDoublePendulum PUBLIC "/permissive-")
+    # disable MSVC inherit via dominance warning
+    target_compile_options(MockDoublePendulum PUBLIC "/wd4250")
+  endif()
 endif()

--- a/tools/check_test_ran.py
+++ b/tools/check_test_ran.py
@@ -44,7 +44,6 @@ NAME="check_test_ran.py"
 
 import os
 import sys
-import subprocess
 
 def usage():
     print("""Usage:
@@ -52,29 +51,6 @@ def usage():
 """%(NAME), file=sys.stderr)
     print(sys.argv)
     sys.exit(getattr(os, 'EX_USAGE', 1))
-
-def run_grep(filename, arg):
-    process = subprocess.Popen(['grep', arg, filename], stdout=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    return stdout, stderr
-
-def run_xsltproc(stylesheet, document):
-    try:
-        process = subprocess.Popen(['xsltproc', stylesheet, document], stdout=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        # Overwrite same document
-        open(document, 'w').write(stdout)
-    except OSError as err:
-        test_name = os.path.basename(document)
-        f = open(document, 'w')
-        d = {'test': test_name, 'test_file': document, 'test_no_xml': test_name.replace('.xml', '')}
-        f.write("""<?xml version="1.0" encoding="UTF-8"?>
-<testsuite tests="1" failures="1" time="1" errors="0" name="%(test)s">
-  <testcase name="test_ran" status="run" time="1" classname="%(test_no_xml)s">
-    <failure message="Unable to find xsltproc. Can not parse output test for QTest suite." type=""/>
-  </testcase>
-</testsuite>"""%d)
-        sys.exit(getattr(os, 'EX_USAGE', 1))
 
 def check_main():
     if len(sys.argv) < 2:
@@ -98,14 +74,6 @@ def check_main():
     <failure message="Unable to find test results for %(test)s, test did not run.\nExpected results in %(test_file)s" type=""/>
   </testcase>
 </testsuite>"""%d)
-        sys.exit(getattr(os, 'EX_USAGE', 1))
-
-    # Checking if test is a QTest file
-    stdout, stderr = run_grep(test_file, "QtVersion")
-    if (stdout):
-        print("Detect QTest xml file. Converting to JUNIT ...")
-        stylesheet = os.path.dirname(os.path.abspath(__file__)) + "/qtest_to_junit.xslt"
-        run_xsltproc(stylesheet, test_file)
 
 if __name__ == '__main__':
     check_main()

--- a/tpe/plugin/CMakeLists.txt
+++ b/tpe/plugin/CMakeLists.txt
@@ -43,7 +43,7 @@ if (WIN32)
   # disable MSVC inherit via dominance warning
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
   INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-      ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned} 
+      ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${versioned}
       ${IGNITION_PHYSICS_ENGINE_INSTALL_DIR}\/${unversioned})")
 else()
   EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})


### PR DESCRIPTION
These are some fixes needed to compile against dartsim on Windows, as mentioned in #87. Though dartsim version 6.9.4 is [now available in vcpkg](https://github.com/microsoft/vcpkg/blob/master/ports/dartsim/portfile.cmake), this version is missing some needed fixes (https://github.com/dartsim/dart/pull/1510, https://github.com/dartsim/dart/pull/1513), so I recommend building dart's `master` branch from source in a colcon workspace alongside this branch. Unfortunately, dart still seems to have some runtime errors (https://github.com/dartsim/dart/issues/1522), so all the tests that use the `dartsim-plugin` currently fail, but at least the build succeeds.

The fixes include:

* creating the unversioned plugin by copy instead of symlink, following the example of TPE
* setting some compiler flags to fix build errors (https://github.com/dartsim/dart/issues/753) and disable some warnings
* remove features related to QTest and UNIX from the `check_test_ran.py` script (based on ign-cmake's [copy of this file](https://github.com/ignitionrobotics/ign-cmake/blob/ignition-cmake2_2.5.0/tools/check_test_ran.py))