### PR TITLE
[Bullet] Erase Entity - Memory Issue

### DIFF
--- a/bullet/src/Base.hh
+++ b/bullet/src/Base.hh
@@ -108,11 +108,14 @@ class Base : public Implements3d<FeatureList<Feature>>
 
   public: inline std::size_t GetNextEntity()
   {
+    ignerr << "GetNextEntity" << std::endl;
     return entityCount++;
   }
 
   public: inline Identity InitiateEngine(std::size_t /*_engineID*/) override
   {
+    ignerr << "InitiateEngine" << std::endl;
+
     const auto id = this->GetNextEntity();
     assert(id == 0);
 
@@ -121,6 +124,7 @@ class Base : public Implements3d<FeatureList<Feature>>
 
   public: inline Identity AddWorld(WorldInfo _worldInfo)
   {
+    ignerr << "AddWorld" << std::endl;
     const auto id = this->GetNextEntity();
     this->worlds[id] = std::make_shared<WorldInfo>(_worldInfo);
     return this->GenerateIdentity(id, this->worlds.at(id));
@@ -129,6 +133,7 @@ class Base : public Implements3d<FeatureList<Feature>>
   public: inline Identity AddModel(ModelInfo _modelInfo)
   {
     const auto id = this->GetNextEntity();
+    ignerr << "AddModel " << id << std::endl;
     this->models[id] = std::make_shared<ModelInfo>(_modelInfo);
 
     return this->GenerateIdentity(id, this->models.at(id));
@@ -136,6 +141,7 @@ class Base : public Implements3d<FeatureList<Feature>>
 
   public: inline Identity AddLink(LinkInfo _linkInfo)
   {
+    ignerr << "AddLink" << std::endl;
     const auto id = this->GetNextEntity();
     this->links[id] = std::make_shared<LinkInfo>(_linkInfo);
 

--- a/bullet/src/EntityManagementFeatures.cc
+++ b/bullet/src/EntityManagementFeatures.cc
@@ -41,14 +41,13 @@ bool EntityManagementFeatures::RemoveModel(const Identity &_modelID)
 
   // Current implementation does not include collisions nor joints
   // Those should be removed here before removing the model
-
-  // Clean up links
-  for (const auto &linkEntry : this->links)
+  std::unordered_map<std::size_t, LinkInfoPtr>::iterator it = this->links.begin();
+  while (it != this->links.end())
   {
-    const auto &linkInfo = linkEntry.second;
+    const auto &linkInfo = it->second;
     if (linkInfo->model.id == _modelID.id)
     {
-      this->links.erase(linkEntry.first);
+      it = this->links.erase(it);
     }
   }
 

--- a/bullet/src/FreeGroupFeatures.cc
+++ b/bullet/src/FreeGroupFeatures.cc
@@ -8,6 +8,7 @@ namespace bullet {
 Identity FreeGroupFeatures::FindFreeGroupForModel(
     const Identity &_modelID) const
 {
+  ignerr << "FindFreeGroupForModel" << std::endl;
   const auto &model = this->models.at(_modelID)->model;
 
   // If there are no links at all in this model, then the FreeGroup functions
@@ -26,6 +27,7 @@ Identity FreeGroupFeatures::FindFreeGroupForModel(
 Identity FreeGroupFeatures::FindFreeGroupForLink(
     const Identity &_linkID) const
 {
+  ignerr << "FindFreeGroupForLink" << std::endl;
   const auto &link_it = this->links.find(_linkID);
 
   if (link_it != this->links.end() && link_it->second != nullptr)
@@ -37,6 +39,7 @@ Identity FreeGroupFeatures::FindFreeGroupForLink(
 Identity FreeGroupFeatures::GetFreeGroupCanonicalLink(
     const Identity &_groupID) const
 {
+  ignerr << "GetFreeGroupCanonicalLink" << std::endl;
   (void) _groupID;
   //  TODO(lobotuerk) when joints are supported, fix canonical getter
   //  Verify that link exists
@@ -67,6 +70,7 @@ void FreeGroupFeatures::SetFreeGroupWorldPose(
     const PoseType &_pose)
 {
   // Convert pose
+  ignerr << "SetFreeGroupWorldPose" << std::endl;
   const auto poseTranslation = _pose.translation();
   const auto poseLinear = _pose.linear();
   btTransform baseTransform;

--- a/bullet/src/KinematicsFeatures.cc
+++ b/bullet/src/KinematicsFeatures.cc
@@ -9,6 +9,7 @@ namespace bullet {
 FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
     const FrameID &_id) const
 {
+  // ignerr << "FrameDataRelativeToWorld" << std::endl;
   FrameData3d data;
 
   // The feature system should never send us the world ID.

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -10,6 +10,7 @@ Identity SDFFeatures::ConstructSdfWorld(
     const Identity &_engine,
     const ::sdf::World &_sdfWorld)
 {
+  ignerr << "ConstructSdfWorld" << std::endl;
   const Identity worldID = this->ConstructEmptyWorld(_engine, _sdfWorld.Name());
 
   const WorldInfoPtr &worldInfo = this->worlds.at(worldID);
@@ -59,6 +60,7 @@ Identity SDFFeatures::ConstructSdfModel(
                                        fixedBase,
                                        canSleep);
 
+  ignerr << "ConstructSdfModel" << model << std::endl;
   model->setBaseWorldTransform(baseTransform);
 
   model->setHasSelfCollision(selfCollide);
@@ -125,6 +127,7 @@ Identity SDFFeatures::ConstructSdfLink(
   const auto linkIdentity = this->AddLink({name, linkIndex, linkMass,
                                   linkInertiaDiag, poseIsometry, _modelID});
 
+  ignerr << "ConstructSdfLink " << linkIdentity.id << std::endl;
   return linkIdentity;
 }
 

--- a/bullet/src/SimulationFeatures.cc
+++ b/bullet/src/SimulationFeatures.cc
@@ -27,6 +27,7 @@ void SimulationFeatures::WorldForwardStep(
     ForwardStep::State & /*_x*/,
     const ForwardStep::Input & _u)
 {
+  // ignerr << "WorldForwardStep" << std::endl;
     const WorldInfoPtr &worldInfo = this->worlds.at(_worldID);
 
     auto *dtDur =


### PR DESCRIPTION
Way to reproduce:
After compiling and sourcing, running `ign gazebo -s -v4 --physics-engine ignition-physics3-bullet-plugin shapes.sdf`, pressing play and deleting the sphere should trigger the `free` related segfault