### PR TITLE
[bullet] Add find or construct link

### DIFF
--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -173,7 +173,7 @@ Identity SDFFeatures::ConstructSdfCollision(
 }
 
 /////////////////////////////////////////////////
-Identity SDFFeatures::FindOrConstructSdfLink(
+std::size_t SDFFeatures::FindOrConstructSdfLink(
   const Identity &_modelID,
   const ::sdf::Link &_sdfLink)
 {
@@ -186,8 +186,8 @@ Identity SDFFeatures::FindOrConstructSdfLink(
     if (linkInfo->name == linkName)
     {
       // A link was previously created with that name,
-      // Return an identity with it
-      return Identity(link.first, link.second);
+      // Return its entity value
+      return link.first;
     }
   }
   return this->ConstructSdfLink(_modelID, _sdfLink);

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -42,7 +42,7 @@ Identity SDFFeatures::ConstructSdfModel(
   // Build links
   for (std::size_t i = 0; i < _sdfModel.LinkCount(); ++i)
   {
-    this->ConstructSdfLink(modelIdentity, *_sdfModel.LinkByIndex(i));
+    this->FindOrConstructSdfLink(modelIdentity, *_sdfModel.LinkByIndex(i));
   }
 
   return modelIdentity;
@@ -170,6 +170,27 @@ Identity SDFFeatures::ConstructSdfCollision(
                                modelID});
   }
   return this->GenerateInvalidId();
+}
+
+/////////////////////////////////////////////////
+Identity SDFFeatures::FindOrConstructSdfLink(
+  const Identity &_modelID,
+  const ::sdf::Link &_sdfLink)
+{
+  // Check if there is a model with the requested name
+  const std::string linkName = _sdfLink.Name();
+
+  for (const auto &link : this->links)
+  {
+    const auto &linkInfo = link.second;
+    if (linkInfo->name == linkName)
+    {
+      // A link was previously created with that name,
+      // Return an identity with it
+      return Identity(link.first, link.second);
+    }
+  }
+  return this->ConstructSdfLink(_modelID, _sdfLink);
 }
 
 }

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -39,12 +39,6 @@ Identity SDFFeatures::ConstructSdfModel(
   // const auto &world = this->worlds.at(_worldID)->world;
   const auto modelIdentity = this->AddModel({name, _worldID, isStatic, pose});
 
-  // Build links
-  for (std::size_t i = 0; i < _sdfModel.LinkCount(); ++i)
-  {
-    this->FindOrConstructSdfLink(modelIdentity, *_sdfModel.LinkByIndex(i));
-  }
-
   return modelIdentity;
 }
 

--- a/bullet/src/SDFFeatures.hh
+++ b/bullet/src/SDFFeatures.hh
@@ -40,6 +40,9 @@ class SDFFeatures :
   private: Identity ConstructSdfCollision(
       const Identity &_linkID,
       const ::sdf::Collision &_collision) override;
+  private: std::size_t FindOrConstructSdfLink(
+      const Identity &_modelID,
+      const ::sdf::Link &_sdfLink);
 };
 
 }


### PR DESCRIPTION
This is to create links in a way similar to dartsim. I think this probably may avoid issues with duplicated links. As bullet doesn't save the names of the links, the names are searched in the `links` unordered map.