### PR TITLE
TPE: Skip computing collisions for static objects

### DIFF
--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -125,6 +125,9 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
   for (auto it = _entities.begin(); it != _entities.end(); ++it)
   {
     std::shared_ptr<Entity> e = it->second;
+    // Skip if the entity is static
+    if (e->GetStatic() == true)
+      continue;
 
     math::AxisAlignedBox b = e->GetBoundingBox();
     if (b == math::AxisAlignedBox())

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -126,7 +126,7 @@ std::vector<Contact> CollisionDetector::CheckCollisions(
   {
     std::shared_ptr<Entity> e = it->second;
     // Skip if the entity is static
-    if (e->GetStatic() == true)
+    if (e->GetStatic())
       continue;
 
     math::AxisAlignedBox b = e->GetBoundingBox();

--- a/tpe/lib/src/CollisionDetector_TEST.cc
+++ b/tpe/lib/src/CollisionDetector_TEST.cc
@@ -241,3 +241,44 @@ TEST(CollisionDetector, CheckCollisions)
   contacts = cd.CheckCollisions(entities, true);
   EXPECT_EQ(1u, contacts.size());
 }
+
+/////////////////////////////////////////////////
+TEST(CollisionDetector, CheckStaticCollisionFiltering)
+{
+  // set up entities for testing collision filtering between static objects
+
+  // model A
+  std::shared_ptr<Model> modelA(new Model);
+  modelA->SetStatic(true);
+  Entity &linkAEnt = modelA->AddLink();
+  Link *linkA = static_cast<Link *>(&linkAEnt);
+  Entity &collisionAEnt = linkA->AddCollision();
+  Collision *collisionA = static_cast<Collision *>(&collisionAEnt);
+  BoxShape boxShapeA;
+  boxShapeA.SetSize(ignition::math::Vector3d(4, 4, 4));
+  collisionA->SetShape(boxShapeA);
+
+  // model B
+  std::shared_ptr<Model> modelB(new Model);
+  modelB->SetStatic(true);
+  Entity &linkBEnt = modelB->AddLink();
+  Link *linkB = static_cast<Link *>(&linkBEnt);
+  Entity &collisionBEnt = linkB->AddCollision();
+  Collision *collisionB = static_cast<Collision *>(&collisionBEnt);
+  BoxShape boxShapeB;
+  boxShapeB.SetSize(ignition::math::Vector3d(4, 4, 4));
+  collisionB->SetShape(boxShapeB);
+
+  // check collisions
+  CollisionDetector cd;
+  std::map<std::size_t, std::shared_ptr<Entity>> entities;
+  // verify that no contacts are reported if the models are static
+  modelA->SetPose(math::Pose3d(1, 1, 1, 0, 0, 0));
+  modelB->SetPose(math::Pose3d(0, 0, 0, 0, 0, 0));
+  entities[modelA->GetId()] = modelA;
+  entities[modelB->GetId()] = modelB;
+
+  std::vector<Contact> contacts = cd.CheckCollisions(entities);
+  EXPECT_TRUE(contacts.empty());
+
+}

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -27,6 +27,9 @@ class ignition::physics::tpelib::EntityPrivate
   /// \brief Entity pose
   public: math::Pose3d pose;
 
+  /// \brief Indicate if the object is static
+  public: bool isStatic = false;
+
   /// \brief Entity Id
   public: std::size_t id = 0u;
 
@@ -146,6 +149,18 @@ math::Pose3d Entity::GetWorldPose() const
     return this->dataPtr->parent->GetWorldPose() * this->dataPtr->pose;
 
   return this->dataPtr->pose;
+}
+
+//////////////////////////////////////////////////
+void Entity::SetStatic(bool _static)
+{
+  this->dataPtr->isStatic = _static;
+}
+
+//////////////////////////////////////////////////
+std::size_t Entity::GetStatic() const
+{
+  return this->dataPtr->isStatic;
 }
 
 //////////////////////////////////////////////////

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -158,7 +158,7 @@ void Entity::SetStatic(bool _static)
 }
 
 //////////////////////////////////////////////////
-std::size_t Entity::GetStatic() const
+bool Entity::GetStatic() const
 {
   return this->dataPtr->isStatic;
 }

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -84,7 +84,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
 
   /// \brief Get the static property
   /// \return Static property
-  public: virtual std::size_t GetStatic() const;
+  public: virtual bool GetStatic() const;
 
   /// \brief Set the id of the entity
   /// \param[in] _unique Id

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -78,6 +78,14 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   /// \return Name of entity
   public: virtual const std::string &GetNameRef() const;
 
+  /// \brief Set the static property
+  /// \param[in] _static static
+  public: virtual void SetStatic(bool _static);
+
+  /// \brief Get the static property
+  /// \return Static property
+  public: virtual std::size_t GetStatic() const;
+
   /// \brief Set the id of the entity
   /// \param[in] _unique Id
   public: virtual void SetId(std::size_t _id);

--- a/tpe/lib/src/Model_TEST.cc
+++ b/tpe/lib/src/Model_TEST.cc
@@ -50,6 +50,10 @@ TEST(Model, BasicAPI)
   model.UpdatePose(0.1, model.GetLinearVelocity(), model.GetAngularVelocity());
   EXPECT_EQ(model.GetPose(), model.GetWorldPose());
 
+  EXPECT_FALSE(model.GetStatic());
+  model.SetStatic(true);
+  EXPECT_TRUE(model.GetStatic());
+
   Model model2;
   EXPECT_NE(model.GetId(), model2.GetId());
 

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -87,6 +87,7 @@ Identity SDFFeatures::ConstructSdfModel(
   // Read sdf params
   const std::string name = _sdfModel.Name();
   const auto pose = ResolveSdfPose(_sdfModel.SemanticPose());
+  const bool is_static = _sdfModel.Static();
 
   auto it = this->worlds.find(_worldID.id);
   if (it == this->worlds.end())
@@ -104,6 +105,7 @@ Identity SDFFeatures::ConstructSdfModel(
   tpelib::Model *model = static_cast<tpelib::Model *>(&ent);
   model->SetName(name);
   model->SetPose(pose);
+  model->SetStatic(is_static);
   const auto modelIdentity = this->AddModel(world->GetId(), *model);
 
   // construct links

--- a/tpe/plugin/src/SDFFeatures.cc
+++ b/tpe/plugin/src/SDFFeatures.cc
@@ -87,7 +87,7 @@ Identity SDFFeatures::ConstructSdfModel(
   // Read sdf params
   const std::string name = _sdfModel.Name();
   const auto pose = ResolveSdfPose(_sdfModel.SemanticPose());
-  const bool is_static = _sdfModel.Static();
+  const bool isStatic = _sdfModel.Static();
 
   auto it = this->worlds.find(_worldID.id);
   if (it == this->worlds.end())
@@ -105,7 +105,7 @@ Identity SDFFeatures::ConstructSdfModel(
   tpelib::Model *model = static_cast<tpelib::Model *>(&ent);
   model->SetName(name);
   model->SetPose(pose);
-  model->SetStatic(is_static);
+  model->SetStatic(isStatic);
   const auto modelIdentity = this->AddModel(world->GetId(), *model);
 
   // construct links


### PR DESCRIPTION
This PR introduces skipping collision checking when going through the AABB tree for static objects.
This change allows large performance gains in worlds with a lot of static objects but very few non static ones.

Apart from some complex test scenarios we are working on (where I observed about 300% performance gain) I went for a pathological case and generated a [shapes_population](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/examples/worlds/shapes_population.sdf.erb) with a total of 1500 shapes (500 per type), all set to static except one and I had about double the performance (12% RTF before, 24% RTF after).

I'm considering adding caching to the CollisionDetector where, if an object didn't move since the previous time step, its collision detection step will be skipped. This would work for most scenarios where a second non static object is moving but would fail if a static object was placed (i.e. "teleported") to collide with the static but not moving object (hope this makes sense!).
This should allow further speedups in worlds with a lot of performers but only a few of them moving at the same time but I'll probably address it in a future PR if the performance gain is significant.