### PR TITLE
Fix TPE poseDirty getter

### DIFF
--- a/dartsim/src/EntityManagementFeatures.cc
+++ b/dartsim/src/EntityManagementFeatures.cc
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include <dart/config.hpp>
 #include <dart/collision/ode/OdeCollisionDetector.hpp>

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -319,7 +319,7 @@ Entity *Entity::GetParent() const
 //////////////////////////////////////////////////
 bool Entity::PoseDirty() const
 {
-  return this->dataPtr->poseDirty == true;
+  return this->dataPtr->poseDirty;
 }
 
 //////////////////////////////////////////////////

--- a/tpe/lib/src/Entity.cc
+++ b/tpe/lib/src/Entity.cc
@@ -319,7 +319,7 @@ Entity *Entity::GetParent() const
 //////////////////////////////////////////////////
 bool Entity::PoseDirty() const
 {
-  return this->dataPtr->poseDirty = true;
+  return this->dataPtr->poseDirty == true;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Classic `=` vs `==` typo that wasn't caught at compile time because of the pimpl's raw pointer not enforcing const correctness.
It disabled the optimization that skipped updating the AABB tree for entities that didn't move, so the PR should help improve performance.