### PR TITLE
Fix compilation with GCC 10.2.0

### DIFF
--- a/include/ignition/physics/Entity.hh
+++ b/include/ignition/physics/Entity.hh
@@ -273,14 +273,15 @@ namespace ignition
       /// \return A pointer to the implementation of FeatureT, or a nullptr if
       /// FeatureT is not available.
       protected: template <typename FeatureT>
-      typename FeatureT::template Implementation<Policy> *Interface();
+      typename FeatureT::template Implementation<PolicyT> *Interface();
 
       /// \brief Same as Interface(), but const-qualified so that const entities
       /// can request const-qualified interfaces from the implementation.
       /// \return A pointer to a const-qualified implementation of F, or a
       /// nullptr if F is not available.
-      protected: template <typename F>
-      const typename F::template Implementation<Policy> *Interface() const;
+      protected: template <typename FeatureT>
+      const typename FeatureT::template Implementation<PolicyT> *Interface()
+          const;
 
       /// \brief This is a pointer to the physics engine implementation, and it
       /// can be used by the object features to find the interfaces that they


### PR DESCRIPTION
Resolves #176.

I don't know why GCC 10 isn't able to associate the `Policy` alias to `PolicyT` correctly. Maybe there's a more appropriate way of fixing this while still using `Policy`, I'm not sure.

I haven't tried the fix with GCC 8 or 9, nor clang. Let's see what CI says.

While at it, I also expanded `F` to `FeatureF` to keep the pattern and make it easier to find.