### PR TITLE
[Bullet] Adds missing getters/setters revolute joints

### DIFF
--- a/bullet/src/JointFeatures.cc
+++ b/bullet/src/JointFeatures.cc
@@ -272,6 +272,15 @@ void JointFeatures::SetJointForce(
     const Identity &_id, const std::size_t _dof, const double _value)
 {
   (void) _dof;
+
+  double internal_value = _value;
+  if(internal_value>0.2) {
+    internal_value = 0.2;
+  }
+  else if(internal_value < -0.2) {
+    internal_value = -0.2;
+  }
+
   if (this->joints.find(_id.id) != this->joints.end())
   {
     const JointInfoPtr &jointInfo = this->joints.at(_id.id);
@@ -295,14 +304,17 @@ void JointFeatures::SetJointForce(
 	  hinge->getRigidBodyB().getWorldTransform().getBasis() *
 	  hingeAxisLocalB;
 
-	btVector3 hingeTorqueA = _value * hingeAxisWorldA;
-	btVector3 hingeTorqueB = _value * hingeAxisWorldB;
+	btVector3 hingeTorqueA = internal_value * hingeAxisWorldA;
+	btVector3 hingeTorqueB = internal_value * hingeAxisWorldB;
+	// btVector3 hingeTorqueA = _value * hingeAxisWorldA;
+	// btVector3 hingeTorqueB = _value * hingeAxisWorldB;
 
 	hinge->getRigidBodyA().applyTorque(hingeTorqueA);
 	hinge->getRigidBodyB().applyTorque(-hingeTorqueB);
       }
     }
   }
+  igndbg << "Joint Torque: " << _id.id << " -> " << _value << std::endl;
 }
 
 /////////////////////////////////////////////////

--- a/bullet/src/JointFeatures.cc
+++ b/bullet/src/JointFeatures.cc
@@ -281,7 +281,9 @@ void JointFeatures::SetJointForce(
       {
 	// Limit the max torque applied to avoid abrupt changes in the
 	// angular position of the joint and losing the angle reference
-	const double thresholdValue = max(min(_value, 0.2)), -0.2);
+	// TO-DO (blast545): this limitation should be based on angular speed
+	// as this breaks the PID controller when setting high values
+	const double thresholdValue = std::max(std::min(_value, 0.1), -0.1);
 
 	// z-axis of constraint frame
 	btVector3 hingeAxisLocalA =

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -292,9 +292,9 @@ Identity SDFFeatures::ConstructSdfJoint(
   axisChild = pose.Rot().RotateVectorReverse(axis);
   axisChild = axisChild.Normalize();
 
-  btHingeConstraint* joint;
+  btHingeAccumulatedAngleConstraint* joint;
   if (parentId != worldId) {
-    joint = new btHingeConstraint(
+    joint = new btHingeAccumulatedAngleConstraint(
       *this->links.at(childId)->link,
       *this->links.at(parentId)->link,
       convertVec(ignition::math::eigen3::convert(pivotChild)),
@@ -303,7 +303,7 @@ Identity SDFFeatures::ConstructSdfJoint(
       convertVec(ignition::math::eigen3::convert(axisParent)));
   }
   else {
-    joint = new btHingeConstraint(
+    joint = new btHingeAccumulatedAngleConstraint(
       *this->links.at(childId)->link,
       convertVec(ignition::math::eigen3::convert(pivotChild)),
       convertVec(ignition::math::eigen3::convert(axisChild)));

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -292,8 +292,9 @@ Identity SDFFeatures::ConstructSdfJoint(
   axisChild = pose.Rot().RotateVectorReverse(axis);
   axisChild = axisChild.Normalize();
 
+  btHingeConstraint* joint;
   if (parentId != worldId) {
-    btHingeConstraint* joint = new btHingeConstraint(
+    joint = new btHingeConstraint(
       *this->links.at(childId)->link,
       *this->links.at(parentId)->link,
       convertVec(ignition::math::eigen3::convert(pivotChild)),
@@ -302,7 +303,7 @@ Identity SDFFeatures::ConstructSdfJoint(
       convertVec(ignition::math::eigen3::convert(axisParent)));
   }
   else {
-    btHingeConstraint* joint = new btHingeConstraint(
+    joint = new btHingeConstraint(
       *this->links.at(childId)->link,
       convertVec(ignition::math::eigen3::convert(pivotChild)),
       convertVec(ignition::math::eigen3::convert(axisChild)));

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -319,11 +319,15 @@ Identity SDFFeatures::ConstructSdfJoint(
   const auto &world = this->worlds.at(modelInfo->world)->world;
   world->addConstraint(joint, true);
   joint->enableFeedback(true);
-  double friction = _sdfJoint.Axis(0)->Friction();
-  joint->enableAngularMotor(true, 0.0, friction);
+
+  if (_sdfJoint.Axis(0) != nullptr) {
+    double friction = _sdfJoint.Axis(0)->Friction();
+    joint->enableAngularMotor(true, 0.0, friction);
+  }
 
   // Generate an identity for it and return it
-  auto identity = this->AddJoint({_sdfJoint.Name(), joint, childId, parentId, static_cast<int>(type), _sdfJoint.Axis(0)->Xyz()});
+  auto identity =
+    this->AddJoint({_sdfJoint.Name(), joint, childId, parentId, static_cast<int>(type), axis});
   return identity;
 }
 

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 #include "SDFFeatures.hh"
 #include <ignition/math/eigen3/Conversions.hh>
 #include <ignition/math/Helpers.hh>
@@ -12,79 +29,6 @@
 namespace ignition {
 namespace physics {
 namespace bullet {
-
-/////////////////////////////////////////////////
-/// \brief Resolve the pose of an SDF DOM object with respect to its relative_to
-/// frame. If that fails, return the raw pose
-// static Eigen::Isometry3d ResolveSdfPose(const ::sdf::SemanticPose &_semPose)
-// {
-//   math::Pose3d pose;
-//   ::sdf::Errors errors = _semPose.Resolve(pose);
-//   if (!errors.empty())
-//   {
-//     if (!_semPose.RelativeTo().empty())
-//     {
-//       ignerr << "There was an error in SemanticPose::Resolve\n";
-//       for (const auto &err : errors)
-//       {
-//         ignerr << err.Message() << std::endl;
-//       }
-//       ignerr << "There is no optimal fallback since the relative_to attribute["
-//              << _semPose.RelativeTo() << "] of the pose is not empty. "
-//              << "Falling back to using the raw Pose.\n";
-//     }
-//     pose = _semPose.RawPose();
-//   }
-//
-//   return math::eigen3::convert(pose);
-// }
-
-/////////////////////////////////////////////////
-// This function was taken directly from dartsim
-// Might need geometry fixes
-// static Eigen::Vector3d ConvertJointAxis(
-//     const ::sdf::JointAxis *_sdfAxis,
-//     const ModelInfo &_modelInfo,
-//     const Eigen::Isometry3d &_T_joint)
-// {
-//   (void) _modelInfo;
-//   (void) _T_joint;
-//   math::Vector3d resolvedAxis;
-//   ::sdf::Errors errors = _sdfAxis->ResolveXyz(resolvedAxis);
-//   if (errors.empty())
-//     return math::eigen3::convert(resolvedAxis);
-//
-//   // Error while Resolving xyz. Fallback sdformat 1.6 behavior but treat
-//   // xyz_expressed_in = "__model__" as the old use_parent_model_frame
-//
-//   const Eigen::Vector3d axis = ignition::math::eigen3::convert(_sdfAxis->Xyz());
-//   return axis;
-//   /*
-//
-//   if (_sdfAxis->XyzExpressedIn().empty())
-//     return axis;
-//
-//   if (_sdfAxis->XyzExpressedIn() == "__model__")
-//   {
-//     ignwarn << "Xyz expressed in model frame is not currently supported, returning raw axis\n";
-//     return axis;
-//   }
-//
-//   // xyz expressed in a frame other than the joint frame or the parent model
-//   // frame is not supported
-//   ignerr << "There was an error in JointAxis::ResolveXyz\n";
-//   for (const auto &err : errors)
-//   {
-//     ignerr << err.Message() << std::endl;
-//   }
-//   ignerr << "There is no optimal fallback since the expressed_in attribute["
-// 	 << _sdfAxis->XyzExpressedIn() << "] of the axis's xyz is neither empty"
-// 	 << "nor '__model__'. Falling back to using the raw xyz vector "
-// 	 << "expressed in the joint frame.\n";
-//
-//   return axis;
-//   */
-// }
 
 /////////////////////////////////////////////////
 Identity SDFFeatures::ConstructSdfWorld(


### PR DESCRIPTION
This PR:

* Adds revoluteJoints with world as parent
* Fixes segfault related to default axis
* Adds missing getters/setters for revoluteJoints

This PR was tested using `joint_controller.sdf` and `joint_position_controller.sdf`