### PR TITLE
[Bullet] Demo Test without wheel_slip_plugin

### DIFF
--- a/bullet/src/JointFeatures.cc
+++ b/bullet/src/JointFeatures.cc
@@ -32,6 +32,7 @@ double JointFeatures::GetJointPosition(
   if (this->joints.find(_id.id) != this->joints.end())
   {
     const JointInfoPtr &jointInfo = this->joints.at(_id.id);
+    // igndbg << "Child: " << jointInfo->childLinkId << " Father: " << jointInfo->parentLinkId << std::endl;
     const int jointType = jointInfo->constraintType;
     // Check the type of joint and act accordignly
     if (jointInfo->constraintType ==
@@ -55,6 +56,13 @@ double JointFeatures::GetJointPosition(
     }
   }
   igndbg << "Position: " << _id.id << " -> " << result << std::endl;
+  const JointInfoPtr &jointInfo = this->joints.at(_id.id);
+  btTransform transP, transC;
+  this->links.at(jointInfo->parentLinkId)->link->getMotionState()->getWorldTransform(transP);
+  this->links.at(jointInfo->childLinkId)->link->getMotionState()->getWorldTransform(transC);
+  btScalar x, y, z;
+  (transP.inverse() * transC).getRotation().getEulerZYX(z,y,x);
+  igndbg << "TF: " << y << std::endl;
   return result;
 }
 

--- a/bullet/src/JointFeatures.cc
+++ b/bullet/src/JointFeatures.cc
@@ -55,14 +55,14 @@ double JointFeatures::GetJointPosition(
       ignerr << "Not a valid constrating type: " << jointType << "\n";
     }
   }
-  igndbg << "Position: " << _id.id << " -> " << result << std::endl;
-  const JointInfoPtr &jointInfo = this->joints.at(_id.id);
-  btTransform transP, transC;
-  this->links.at(jointInfo->parentLinkId)->link->getMotionState()->getWorldTransform(transP);
-  this->links.at(jointInfo->childLinkId)->link->getMotionState()->getWorldTransform(transC);
-  btScalar x, y, z;
-  (transP.inverse() * transC).getRotation().getEulerZYX(z,y,x);
-  igndbg << "TF: " << y << std::endl;
+  // igndbg << "Position: " << _id.id << " -> " << result << std::endl;
+  // const JointInfoPtr &jointInfo = this->joints.at(_id.id);
+  // btTransform transP, transC;
+  // this->links.at(jointInfo->parentLinkId)->link->getMotionState()->getWorldTransform(transP);
+  // this->links.at(jointInfo->childLinkId)->link->getMotionState()->getWorldTransform(transC);
+  // btScalar x, y, z;
+  // (transP.inverse() * transC).getRotation().getEulerZYX(z,y,x);
+  // igndbg << "TF: " << y << std::endl;
   return result;
 }
 

--- a/bullet/src/SDFFeatures.cc
+++ b/bullet/src/SDFFeatures.cc
@@ -238,6 +238,7 @@ Identity SDFFeatures::ConstructSdfCollision(
   const auto &odeFriction = surfaceElement->GetElement("friction")
                               ->GetElement("ode");
   const auto mu = odeFriction->Get<btScalar>("mu");
+  const auto mu2 = odeFriction->Get<btScalar>("mu2");
 
   // Get restitution
   // const auto restitution = surfaceElement->GetElement("bounce")
@@ -263,8 +264,8 @@ Identity SDFFeatures::ConstructSdfCollision(
 
     // shape->setMargin(btScalar(0.0001));
 
-    body->setFriction(mu * 10);
-    body->setAnisotropicFriction(btVector3(1, 1, 1),
+    body->setFriction(1);
+    body->setAnisotropicFriction(btVector3(mu, mu2, 1),
     btCollisionObject::CF_ANISOTROPIC_FRICTION);
 
     dynamic_cast<btCompoundShape *>(body->getCollisionShape())->addChildShape(baseTransform, shape);


### PR DESCRIPTION
Signed-off-by: Tomas Lorente <jtlorente@ekumenlabs.com>

So, for testing purposes, I used subt  cave_circuit from this fork https://github.com/Lobotuerk/subt/tree/bullet_test, you don't necessarily need the fork, but you need to specify on the launch file for physics to use the bullet_engine. The fork has an `engine:=` parameter, that you can set to dart/bullet to change the physics engine. If using subt from master repo, add this into the launch file ```<plugin entity_name="<%= $worldName %>"
            entity_type="world"
            filename="libignition-gazebo-physics-system.so"
            name="ignition::gazebo::systems::Physics">
            <engine><filename>libignition-physics-bullet-plugin.so</filename></engine>
    </plugin>```

For installing the branch, install ignition dome from src and checkout the ign-physics repo to this branch, `bulletDev/Lobotuerk/ParameterTuning`. Source the installation and export the engine with `export IGN_GAZEBO_PHYSICS_ENGINE_PATH=~/PATH/TO/IGN/INSTALL/FOLDER//lib/ign-physics-4/engine-plugins/` (I'm not sure if we are missing something on the cmake that should take care of the exporting).
Then install subt from source and after sourcing it, you should be able to launch cave_circuit with bullet