### PR TITLE
[Bullet] Removing GetContactsFromLastStepFeature from Simulation Features

### DIFF
--- a/bullet/src/SimulationFeatures.hh
+++ b/bullet/src/SimulationFeatures.hh
@@ -20,7 +20,6 @@
 
 #include <vector>
 #include <ignition/physics/ForwardStep.hh>
-#include <ignition/physics/GetContacts.hh>
 
 #include "Base.hh"
 
@@ -29,8 +28,7 @@ namespace physics {
 namespace bullet {
 
 using SimulationFeatureList = FeatureList<
-  ForwardStep,
-  GetContactsFromLastStepFeature
+  ForwardStep
 >;
 
 class SimulationFeatures :
@@ -42,14 +40,6 @@ class SimulationFeatures :
       ForwardStep::Output &_h,
       ForwardStep::State &_x,
       const ForwardStep::Input &_u) override;
-
-  public: std::vector<ContactInternal> GetContactsFromLastStep(
-      const Identity &/* _worldID */) const override
-      {
-        // TODO(lobotuerk): Implement contacts getter, could be like https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=2855
-        ignerr << "Dummy GetContactsFromLastStep implementation";
-        return std::vector<ContactInternal>();
-      };
 };
 
 }  // namespace bullet


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
Removed GetContactsFromLastStepFeature from the engine's features.

## Test it
Compile and try running any simulation with bullet engine, depends on https://github.com/ignitionrobotics/ign-gazebo/pull/690

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
