### PR TITLE
Add "ChangedWorldPose" to ForwardStep::Output's expected data

### DIFF
--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -59,15 +59,15 @@ void SimulationFeatures::WorldForwardStep(
 
   // TODO(MXG): Parse input
   world->step();
-  this->WriteRequiredData(_h);
+  this->Write(_h.Get<ChangedWorldPoses>());
   // TODO(MXG): Fill in state
 }
 
-void SimulationFeatures::Write(WorldPoses &_poses) const
+void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
 {
   // remove link poses from the previous iteration
-  _poses.entries.clear();
-  _poses.entries.reserve(this->links.size());
+  _changedPoses.entries.clear();
+  _changedPoses.entries.reserve(this->links.size());
 
   std::unordered_map<std::size_t, math::Pose3d> newPoses;
 
@@ -88,7 +88,7 @@ void SimulationFeatures::Write(WorldPoses &_poses) const
           !iter->second.Pos().Equal(wp.pose.Pos(), 1e-6) ||
           !iter->second.Rot().Equal(wp.pose.Rot(), 1e-6))
       {
-        _poses.entries.push_back(wp);
+        _changedPoses.entries.push_back(wp);
         newPoses[id] = wp.pose;
       }
       else

--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -26,6 +26,7 @@
 #include <ignition/physics/CanWriteData.hh>
 #include <ignition/physics/ForwardStep.hh>
 #include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/SpecifyData.hh>
 
 #include "Base.hh"
 
@@ -39,7 +40,8 @@ struct SimulationFeatureList : FeatureList<
 > { };
 
 class SimulationFeatures :
-    public CanWriteRequiredData<SimulationFeatures, ForwardStep::Output>,
+    public CanWriteExpectedData<SimulationFeatures,
+      ExpectData<ChangedWorldPoses>>,
     public virtual Base,
     public virtual Implements3d<SimulationFeatureList>
 {
@@ -49,7 +51,7 @@ class SimulationFeatures :
       ForwardStep::State &_x,
       const ForwardStep::Input &_u) override;
 
-  public: void Write(WorldPoses &_poses) const;
+  public: void Write(ChangedWorldPoses &_changedPoses) const;
 
   public: std::vector<ContactInternal> GetContactsFromLastStep(
       const Identity &_worldID) const override;

--- a/dartsim/src/SimulationFeatures_TEST.cc
+++ b/dartsim/src/SimulationFeatures_TEST.cc
@@ -117,7 +117,7 @@ bool StepWorld(const TestWorldPtr &_world, bool _firstTime,
     if (_firstTime && (i == 0))
     {
       EXPECT_FALSE(
-          output.Get<ignition::physics::WorldPoses>().entries.empty());
+          output.Get<ignition::physics::ChangedWorldPoses>().entries.empty());
       checkedOutput = true;
     }
   }

--- a/include/ignition/physics/ForwardStep.hh
+++ b/include/ignition/physics/ForwardStep.hh
@@ -49,6 +49,15 @@ namespace ignition
       std::string annotation;
     };
 
+    /// \brief ChangedWorldPoses has the same definition as WorldPoses.
+    /// This type provides a way to keep track of which poses have changed in a
+    /// simulation step.
+    struct ChangedWorldPoses
+    {
+      std::vector<WorldPose> entries;
+      std::string annotation;
+    };
+
     struct Point
     {
       ignition::math::Vector3d point;
@@ -150,7 +159,7 @@ namespace ignition
 
       public: using Output = SpecifyData<
           RequireData<WorldPoses>,
-          ExpectData<Contacts, JointPositions> >;
+          ExpectData<ChangedWorldPoses, Contacts, JointPositions> >;
 
       public: using State = CompositeData;
 

--- a/tpe/plugin/src/SimulationFeatures.cc
+++ b/tpe/plugin/src/SimulationFeatures.cc
@@ -62,14 +62,14 @@ void SimulationFeatures::WorldForwardStep(
     }
   }
   world->Step();
-  this->WriteRequiredData(_h);
+  this->Write(_h.Get<ChangedWorldPoses>());
 }
 
-void SimulationFeatures::Write(WorldPoses &_poses) const
+void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
 {
   // remove link poses from the previous iteration
-  _poses.entries.clear();
-  _poses.entries.reserve(this->links.size());
+  _changedPoses.entries.clear();
+  _changedPoses.entries.reserve(this->links.size());
 
   std::unordered_map<std::size_t, math::Pose3d> newPoses;
 
@@ -90,7 +90,7 @@ void SimulationFeatures::Write(WorldPoses &_poses) const
         WorldPose wp;
         wp.pose = nextPose;
         wp.body = id;
-        _poses.entries.push_back(wp);
+        _changedPoses.entries.push_back(wp);
         newPoses[id] = nextPose;
       }
       else

--- a/tpe/plugin/src/SimulationFeatures.hh
+++ b/tpe/plugin/src/SimulationFeatures.hh
@@ -26,6 +26,7 @@
 #include <ignition/physics/CanWriteData.hh>
 #include <ignition/physics/ForwardStep.hh>
 #include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/SpecifyData.hh>
 
 #include "Base.hh"
 
@@ -39,7 +40,8 @@ struct SimulationFeatureList : FeatureList<
 > { };
 
 class SimulationFeatures :
-  public CanWriteRequiredData<SimulationFeatures, ForwardStep::Output>,
+  public CanWriteExpectedData<SimulationFeatures,
+    ExpectData<ChangedWorldPoses>>,
   public virtual Base,
   public virtual Implements3d<SimulationFeatureList>
 {
@@ -49,7 +51,7 @@ class SimulationFeatures :
     ForwardStep::State &_x,
     const ForwardStep::Input &_u) override;
 
-  public: void Write(WorldPoses &_poses) const;
+  public: void Write(ChangedWorldPoses &_changedPoses) const;
 
   public: std::vector<ContactInternal> GetContactsFromLastStep(
     const Identity &_worldID) const override;

--- a/tpe/plugin/src/SimulationFeatures_TEST.cc
+++ b/tpe/plugin/src/SimulationFeatures_TEST.cc
@@ -116,7 +116,7 @@ bool StepWorld(const TestWorldPtr &_world, bool _firstTime,
     if (_firstTime && (i == 0))
     {
       EXPECT_FALSE(
-          output.Get<ignition::physics::WorldPoses>().entries.empty());
+          output.Get<ignition::physics::ChangedWorldPoses>().entries.empty());
       checkedOutput = true;
     }
   }


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

Related to #223 

Possible solution for #219

## Summary

#223 added functionality to DART and TPE to write changed link data from an iteration to `ForwardStep::Output` so that downstream libraries like `ign-gazebo` can use this data for more efficient post-physics processing/updates (https://github.com/ignitionrobotics/ign-gazebo/pull/678). In order for downstream libraries to make this functionality optional, the changed link data that is written to by DART and TPE must be of type `ExpectedData` instead of `RequiredData` (that way, downstream libraries can see if this data was actually written to or not). This PR makes this change.

## Test it

Using this PR with https://github.com/ignitionrobotics/ign-gazebo/pull/678, users can run the [`ign-gazebo` physics system integration test](https://github.com/ignitionrobotics/ign-gazebo/blob/040b4a16fe162c167852c519895fac01543c1876/test/integration/physics_system.cc). This will use the output link data that `ign-physics` writes to in order to update the simulation state in `ign-gazebo`. All checks in the integration test should pass.

Users can then check out DART and TPE before these engines were modified to write output data (commit https://github.com/ignitionrobotics/ign-physics/commit/109de85195755f855b32cae088849ce17245ff61):
```
cd ign-physics
git checkout 109de85 -- dartsim/ tpe/
```
Re-run the physics integration test. This will use data internal to `ign-gazebo` (a local link pose cache in combination with the EntityComponentManager) to update the simulation state. All checks in the integration test should pass.

_If you'd like to verify that the steps I described above use both data written to from `ign-physics` and data internal to `ign-gazebo`, you can add some print statements in each `if`/`else` block [here](https://github.com/ignitionrobotics/ign-gazebo/blob/040b4a16fe162c167852c519895fac01543c1876/src/systems/physics/Physics.cc#L1730-L1783) to see what is being called._

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**