### PR TITLE
make detail symbols hidden

### DIFF
--- a/include/ignition/physics/detail/CompositeData.hh
+++ b/include/ignition/physics/detail/CompositeData.hh
@@ -32,7 +32,7 @@ namespace ignition
     /// \brief Struct which contains information about a data type within the
     /// CompositeData.
     /// \private
-    struct IGNITION_PHYSICS_VISIBLE CompositeData::DataEntry
+    struct IGNITION_PHYSICS_HIDDEN CompositeData::DataEntry
     {
       /// \brief Default constructor
       public: DataEntry();

--- a/include/ignition/physics/detail/Identity.hh
+++ b/include/ignition/physics/detail/Identity.hh
@@ -37,7 +37,7 @@ namespace ignition
       /////////////////////////////////////////////////
       /// \brief This base class is used by plugin implementations to generate
       /// identities for entities.
-      class IGNITION_PHYSICS_VISIBLE Implementation
+      class IGNITION_PHYSICS_HIDDEN Implementation
       {
         /// \brief An implementation class should call this function whenever it
         /// wants to generate an identity for an Entity.
@@ -70,7 +70,7 @@ namespace ignition
     /// separate class in order to have tight control over how Entities can be
     /// instantiated; in particular, an Identity can only be created by a
     /// plugin implementation, so users cannot create invalid Entities.
-    class IGNITION_PHYSICS_VISIBLE Identity
+    class IGNITION_PHYSICS_HIDDEN Identity
     {
       /// \brief Convert to true if this Identity refers to a valid entity (i.e.
       /// its id field is not INVALID_ENTITY_ID).


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

<!-- Please remove the appropriate section.
For example, if this is a new feature, remove the "Bug Report" section -->

## Summary
After noticing that a `detail` class in `ign-gazebo` was not marked as `hidden` (https://github.com/ignitionrobotics/ign-gazebo/issues/759), I looked through the other ignition repositories and found that there are a few detail symbols in `ign-physics` that should be marked as `hidden` as well.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**