### PR TITLE
Clean up functions that trigger GCC9 warnings

### DIFF
--- a/tpe/lib/src/AABBTree.cc
+++ b/tpe/lib/src/AABBTree.cc
@@ -53,9 +53,7 @@ AABBTree::AABBTree()
 }
 
 //////////////////////////////////////////////////
-AABBTree::~AABBTree()
-{
-}
+AABBTree::~AABBTree() = default;
 
 //////////////////////////////////////////////////
 void AABBTree::AddNode(std::size_t _id, const math::AxisAlignedBox &_aabb)

--- a/tpe/lib/src/Collision.hh
+++ b/tpe/lib/src/Collision.hh
@@ -47,7 +47,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Collision : public Entity
   public: Collision(const Collision &_other);
 
   /// \brief Destructor
-  public: ~Collision();
+  public: virtual ~Collision();
 
   /// \brief Assignment operator
   /// \param[in] _other collision

--- a/tpe/lib/src/CollisionDetector.cc
+++ b/tpe/lib/src/CollisionDetector.cc
@@ -59,9 +59,7 @@ CollisionDetector::CollisionDetector()
 }
 
 //////////////////////////////////////////////////
-CollisionDetector::~CollisionDetector()
-{
-}
+CollisionDetector::~CollisionDetector() = default;
 
 //////////////////////////////////////////////////
 std::vector<Contact> CollisionDetector::CheckCollisions(

--- a/tpe/lib/src/Entity.hh
+++ b/tpe/lib/src/Entity.hh
@@ -60,7 +60,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Entity
   protected: explicit Entity(std::size_t _id);
 
   /// \brief Destructor
-  public: ~Entity();
+  public: virtual ~Entity();
 
   /// \brief Assignment operator
   /// \param[in] _other Other entity to copy from

--- a/tpe/lib/src/Link.hh
+++ b/tpe/lib/src/Link.hh
@@ -39,7 +39,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Link : public Entity
   public: explicit Link(std::size_t _id);
 
   /// \brief Destructor
-  public: ~Link() = default;
+  public: virtual ~Link() = default;
 
   /// \brief Add a collision
   /// \return Newly created Collision

--- a/tpe/lib/src/Model.hh
+++ b/tpe/lib/src/Model.hh
@@ -42,7 +42,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Model : public Entity
   public: explicit Model(std::size_t _id);
 
   /// \brief Destructor
-  public: ~Model();
+  public: virtual ~Model();
 
   /// \brief Add a link
   /// \return Newly created Link

--- a/tpe/lib/src/Shape.cc
+++ b/tpe/lib/src/Shape.cc
@@ -57,18 +57,6 @@ BoxShape::BoxShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-BoxShape::BoxShape(const BoxShape &_other)
-  : Shape()
-{
-  *this = _other;
-}
-
-//////////////////////////////////////////////////
-BoxShape::~BoxShape()
-{
-}
-
-//////////////////////////////////////////////////
 Shape &BoxShape::operator=(const Shape &_other)
 {
   auto other = static_cast<const BoxShape *>(&_other);
@@ -101,13 +89,6 @@ void BoxShape::UpdateBoundingBox()
 CylinderShape::CylinderShape() : Shape()
 {
   this->type = ShapeType::CYLINDER;
-}
-
-//////////////////////////////////////////////////
-CylinderShape::CylinderShape(const CylinderShape &_other)
-  : Shape()
-{
-  *this = _other;
 }
 
 //////////////////////////////////////////////////
@@ -159,13 +140,6 @@ SphereShape::SphereShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-SphereShape::SphereShape(const SphereShape &_other)
-  : Shape()
-{
-  *this = _other;
-}
-
-//////////////////////////////////////////////////
 Shape &SphereShape::operator=(const Shape &_other)
 {
   auto other = static_cast<const SphereShape *>(&_other);
@@ -197,13 +171,6 @@ void SphereShape::UpdateBoundingBox()
 MeshShape::MeshShape() : Shape()
 {
   this->type = ShapeType::MESH;
-}
-
-//////////////////////////////////////////////////
-MeshShape::MeshShape(const MeshShape &_other)
-  : Shape()
-{
-  *this = _other;
 }
 
 //////////////////////////////////////////////////
@@ -245,5 +212,3 @@ void MeshShape::UpdateBoundingBox()
   this->bbox = math::AxisAlignedBox(
       this->scale * this->meshAABB.Min(), this->scale * this->meshAABB.Max());
 }
-
-

--- a/tpe/lib/src/Shape.hh
+++ b/tpe/lib/src/Shape.hh
@@ -63,7 +63,7 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE Shape
   public: Shape();
 
   /// \brief Destructor
-  public: ~Shape() = default;
+  public: virtual ~Shape() = default;
 
   /// \brief Get bounding box of shape
   /// \return Shape's bounding box
@@ -92,12 +92,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE BoxShape : public Shape
   /// \brief Constructor
   public: BoxShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: BoxShape(const BoxShape &_other);
-
   /// \brief Destructor
-  public: ~BoxShape();
+  public: virtual ~BoxShape() = default;
 
   /// \brief Assignment operator
   /// \param[in] _other shape to copy from
@@ -126,12 +122,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE CylinderShape : public Shape
   /// \brief Constructor
   public: CylinderShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: CylinderShape(const CylinderShape &_other);
-
   /// \brief Destructor
-  public: ~CylinderShape() = default;
+  public: virtual ~CylinderShape() = default;
 
   /// \brief Assignment operator
   /// \param[in] _other shape to copy from
@@ -169,12 +161,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE SphereShape : public Shape
   /// \brief Constructor
   public: SphereShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: SphereShape(const SphereShape &_other);
-
   /// \brief Destructor
-  public: ~SphereShape() = default;
+  public: virtual ~SphereShape() = default;
 
   /// \brief Assignment operator
   /// \param[in] _other shape to copy from
@@ -201,12 +189,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE MeshShape : public Shape
   /// \brief Constructor
   public: MeshShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: MeshShape(const MeshShape &_other);
-
   /// \brief Destructor
-  public: ~MeshShape() = default;
+  public: virtual ~MeshShape() = default;
 
   /// \brief Assignment operator
   /// \param[in] _other shape to copy from


### PR DESCRIPTION
Removes unnecessary copy constructors and insures that all destructors are marked `virtual` where appropriate.

Signed-off-by: Michael Carroll <michael@openrobotics.org>
