### PR TITLE
Fix dart deprecation warning

### DIFF
--- a/test/plugins/DARTDoublePendulum.cc
+++ b/test/plugins/DARTDoublePendulum.cc
@@ -73,7 +73,12 @@ namespace mock
 
         for (std::size_t i=0; i < robot->getNumJoints(); ++i)
         {
+// From upstream 6.10.0 or OSRF 6.10.0~osrf19~2021-06-10
+#if DART_VERSION_AT_LEAST(6, 10, 0)
+          this->robot->getJoint(i)->setLimitEnforcement(false);
+#else
           this->robot->getJoint(i)->setPositionLimitEnforced(false);
+#endif
           this->robot->getJoint(i)->setDampingCoefficient(0, 0);
         }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fix for dart deprecation warning copied from #262.

## Summary

Keep using the old method for dart 6.9 and earlier, but use the new method for 6.10+.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
