### PR TITLE
Use slip compliance API's available in upstream dartsim release

### DIFF
--- a/dartsim/src/SDFFeatures.cc
+++ b/dartsim/src/SDFFeatures.cc
@@ -562,7 +562,7 @@ Identity SDFFeatures::ConstructSdfCollision(
     }
     if (odeFriction->HasElement("slip1"))
     {
-      aspect->setSlipCompliance(odeFriction->Get<double>("slip1"));
+      aspect->setPrimarySlipCompliance(odeFriction->Get<double>("slip1"));
     }
     if (odeFriction->HasElement("slip2"))
     {

--- a/dartsim/src/ShapeFeatures.cc
+++ b/dartsim/src/ShapeFeatures.cc
@@ -347,7 +347,7 @@ double ShapeFeatures::GetShapeFrictionPyramidPrimarySlipCompliance(
       << std::endl;
     return 0.0;
   }
-  return aspect->getSlipCompliance();
+  return aspect->getPrimarySlipCompliance();
 }
 
 /////////////////////////////////////////////////
@@ -383,7 +383,7 @@ bool ShapeFeatures::SetShapeFrictionPyramidPrimarySlipCompliance(
       << std::endl;
     return false;
   }
-  aspect->setSlipCompliance(_value);
+  aspect->setPrimarySlipCompliance(_value);
   return true;
 }
 

--- a/dartsim/src/ShapeFeatures_TEST.cc
+++ b/dartsim/src/ShapeFeatures_TEST.cc
@@ -70,6 +70,7 @@ using TestFeatureList = ignition::physics::FeatureList<
   physics::RevoluteJointCast,
   physics::SetJointVelocityCommandFeature,
 #if DART_VERSION_AT_LEAST(6, 10, 0)
+  physics::GetShapeFrictionPyramidSlipCompliance,
   physics::SetShapeFrictionPyramidSlipCompliance,
 #endif
   physics::sdf::ConstructSdfModel,
@@ -180,7 +181,11 @@ TEST_F(ShapeFeaturesFixture, PrimarySlipCompliance)
   const Eigen::Vector3d cmdForce{1, 0, 0};
   const double primarySlip = 0.5;
 
+  // expect 0.0 initial slip
+  EXPECT_DOUBLE_EQ(0.0, boxShape->GetPrimarySlipCompliance());
+
   boxShape->SetPrimarySlipCompliance(primarySlip);
+  EXPECT_DOUBLE_EQ(primarySlip, boxShape->GetPrimarySlipCompliance());
 
   const std::size_t numSteps = 10000;
   for (std::size_t i = 0; i < numSteps; ++i)
@@ -239,7 +244,11 @@ TEST_F(ShapeFeaturesFixture, SecondarySlipCompliance)
   const Eigen::Vector3d cmdForce{0, 1, 0};
   const double secondarySlip = 0.25;
 
+  // expect 0.0 initial slip
+  EXPECT_DOUBLE_EQ(0.0, boxShape->GetSecondarySlipCompliance());
+
   boxShape->SetSecondarySlipCompliance(secondarySlip);
+  EXPECT_DOUBLE_EQ(secondarySlip, boxShape->GetSecondarySlipCompliance());
 
   const std::size_t numSteps = 10000;
   for (std::size_t i = 0; i < numSteps; ++i)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes API incompatibility between upstream and our fork of dart

## Summary

The `getSlipCompliance` and `setSlipCompliance` APIs were present in our fork of dartsim 6.10.0 but not in the recent upstream release. The `getPrimarySlipCompliance` and `setPrimarySlipCompliance` are used in the upstream release of dartsim 6.10.0 and were recently added for our fork of dart, so we should use them for compatibility. A replacement for #249

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
