### PR TITLE
Allow customization of contact surface properties

### DIFF
--- a/dartsim/src/SimulationFeatures.cc
+++ b/dartsim/src/SimulationFeatures.cc
@@ -17,6 +17,9 @@
 
 #include <dart/collision/CollisionObject.hpp>
 #include <dart/collision/CollisionResult.hpp>
+#include <dart/constraint/ContactConstraint.hpp>
+#include <dart/constraint/ContactSurface.hpp>
+#include <dart/constraint/ConstraintSolver.hpp>
 
 #include "SimulationFeatures.hh"
 
@@ -26,6 +29,53 @@
 namespace ignition {
 namespace physics {
 namespace dartsim {
+
+class IgnContactSurfaceHandler : public dart::constraint::ContactSurfaceHandler
+{
+  public: dart::constraint::ContactSurfaceParams createParams(
+    const dart::collision::Contact& _contact,
+    size_t _numContactsOnCollisionObject) const override;
+
+  public: dart::constraint::ContactConstraintPtr createConstraint(
+    dart::collision::Contact& _contact,
+    size_t _numContactsOnCollisionObject,
+    double _timeStep) const override;
+
+  public: typedef SetContactJointPropertiesCallbackFeature Feature;
+  public: typedef Feature::Implementation<FeaturePolicy3d> Impl;
+
+  public: Impl::SurfaceParamsCallback surfaceParamsCallback;
+
+  public: std::function<
+    std::optional<Impl::ContactImpl>(const dart::collision::Contact&)
+  > convertContact;
+
+  public: mutable typename Feature::ContactSurfaceParams<FeaturePolicy3d>
+    lastIgnParams;
+};
+using IgnContactSurfaceHandlerPtr = std::shared_ptr<IgnContactSurfaceHandler>;
+
+class SimulationFeaturesPrivate
+{
+  public: explicit SimulationFeaturesPrivate(SimulationFeatures* _main);
+
+  public: std::optional<SimulationFeatures::ContactInternal> convertContact(
+    const dart::collision::Contact& _contact) const;
+
+  public: std::unordered_map<
+    std::string, IgnContactSurfaceHandlerPtr> contactSurfaceHandlers;
+
+  private: SimulationFeatures* main;
+};
+
+SimulationFeatures::SimulationFeatures()
+  : dataPtr(std::make_unique<SimulationFeaturesPrivate>(this))
+{
+}
+
+SimulationFeatures::~SimulationFeatures()
+{
+}
 
 void SimulationFeatures::WorldForwardStep(
     const Identity &_worldID,
@@ -64,41 +114,182 @@ SimulationFeatures::GetContactsFromLastStep(const Identity &_worldID) const
 
   for (const auto &dtContact : colResult.getContacts())
   {
-    dart::collision::CollisionObject *dtCollObj1 = dtContact.collisionObject1;
-    dart::collision::CollisionObject *dtCollObj2 = dtContact.collisionObject2;
-
-    const dart::dynamics::ShapeFrame *dtShapeFrame1 =
-      dtCollObj1->getShapeFrame();
-    const dart::dynamics::ShapeFrame *dtShapeFrame2 =
-      dtCollObj2->getShapeFrame();
-
-    dart::dynamics::ConstBodyNodePtr dtBodyNode1;
-    dart::dynamics::ConstBodyNodePtr dtBodyNode2;
-
-    if (this->shapes.HasEntity(dtShapeFrame1->asShapeNode()) &&
-        this->shapes.HasEntity(dtShapeFrame2->asShapeNode()))
-    {
-      std::size_t shape1ID =
-          this->shapes.IdentityOf(dtShapeFrame1->asShapeNode());
-      std::size_t shape2ID =
-          this->shapes.IdentityOf(dtShapeFrame2->asShapeNode());
-
-      CompositeData extraData;
-
-      // Add normal, depth and wrench to extraData.
-      auto &extraContactData = extraData.Get<ExtraContactData>();
-      extraContactData.force = dtContact.force;
-      extraContactData.normal = dtContact.normal;
-      extraContactData.depth = dtContact.penetrationDepth;
-
-      outContacts.push_back(
-          {this->GenerateIdentity(shape1ID, this->shapes.at(shape1ID)),
-           this->GenerateIdentity(shape2ID, this->shapes.at(shape2ID)),
-           dtContact.point, extraData});
-    }
+    auto contact = this->dataPtr->convertContact(dtContact);
+    if (contact)
+      outContacts.push_back(contact.value());
   }
+
   return outContacts;
 }
+
+void SimulationFeatures::AddContactJointPropertiesCallback(
+  const Identity& _worldID, const std::string& _callbackID,
+  SurfaceParamsCallback _callback)
+{
+  auto *world = this->ReferenceInterface<DartWorld>(_worldID);
+
+  auto handler = std::make_shared<IgnContactSurfaceHandler>();
+  handler->surfaceParamsCallback = _callback;
+  handler->convertContact = [this](const dart::collision::Contact& _contact) {
+    return this->dataPtr->convertContact(_contact);
+  };
+
+  this->dataPtr->contactSurfaceHandlers[_callbackID] = handler;
+  world->getConstraintSolver()->setContactSurfaceHandler(handler);
+}
+
+bool SimulationFeatures::RemoveContactJointPropertiesCallback(
+  const Identity& _worldID, const std::string& _callbackID)
+{
+  auto *world = this->ReferenceInterface<DartWorld>(_worldID);
+
+  if (this->dataPtr->contactSurfaceHandlers.find(_callbackID) !=
+    this->dataPtr->contactSurfaceHandlers.end())
+  {
+    const auto handler = this->dataPtr->contactSurfaceHandlers[_callbackID];
+    this->dataPtr->contactSurfaceHandlers.erase(_callbackID);
+    return world->getConstraintSolver()->removeContactSurfaceHandler(handler);
+  }
+  else
+  {
+    ignerr << "Could not find the contact surface handler to be removed"
+           << std::endl;
+    return false;
+  }
+}
+
+std::optional<SimulationFeatures::ContactInternal>
+SimulationFeaturesPrivate::convertContact(
+  const dart::collision::Contact& _contact) const
+{
+  auto *dtCollObj1 = _contact.collisionObject1;
+  auto *dtCollObj2 = _contact.collisionObject2;
+
+  auto *dtShapeFrame1 = dtCollObj1->getShapeFrame();
+  auto *dtShapeFrame2 = dtCollObj2->getShapeFrame();
+
+  if (this->main->shapes.HasEntity(dtShapeFrame1->asShapeNode()) &&
+      this->main->shapes.HasEntity(dtShapeFrame2->asShapeNode()))
+  {
+    std::size_t shape1ID =
+      this->main->shapes.IdentityOf(dtShapeFrame1->asShapeNode());
+    std::size_t shape2ID =
+      this->main->shapes.IdentityOf(dtShapeFrame2->asShapeNode());
+
+    CompositeData extraData;
+
+    // Add normal, depth and wrench to extraData.
+    auto& extraContactData =
+      extraData.Get<SimulationFeatures::ExtraContactData>();
+    extraContactData.force = _contact.force;
+    extraContactData.normal = _contact.normal;
+    extraContactData.depth = _contact.penetrationDepth;
+
+
+    return SimulationFeatures::ContactInternal {
+      this->main->GenerateIdentity(shape1ID, this->main->shapes.at(shape1ID)),
+      this->main->GenerateIdentity(shape2ID, this->main->shapes.at(shape2ID)),
+      _contact.point, extraData
+    };
+  }
+
+  return std::nullopt;
+}
+
+SimulationFeaturesPrivate::SimulationFeaturesPrivate(SimulationFeatures* _main)
+  : main(_main)
+{
+}
+
+dart::constraint::ContactSurfaceParams IgnContactSurfaceHandler::createParams(
+  const dart::collision::Contact& _contact,
+  const size_t _numContactsOnCollisionObject) const
+{
+  auto pDart = ContactSurfaceHandler::createParams(
+    _contact, _numContactsOnCollisionObject);
+
+  if (!this->surfaceParamsCallback)
+    return pDart;
+
+  typedef SetContactJointPropertiesCallbackFeature F;
+  typedef FeaturePolicy3d P;
+  typename F::ContactSurfaceParams<P> pIgn;
+
+  pIgn.Get<F::FrictionCoeff<P>>().frictionCoeff = pDart.mFrictionCoeff;
+  pIgn.Get<F::SecondaryFrictionCoeff<P>>().secondaryFrictionCoeff =
+    pDart.mSecondaryFrictionCoeff;
+  pIgn.Get<F::SlipCompliance<P>>().slipCompliance = pDart.mSlipCompliance;
+  pIgn.Get<F::SecondarySlipCompliance<P>>().secondarySlipCompliance =
+    pDart.mSecondarySlipCompliance;
+  pIgn.Get<F::RestitutionCoeff<P>>().restitutionCoeff =
+    pDart.mRestitutionCoeff;
+  pIgn.Get<F::FirstFrictionalDirection<P>>().firstFrictionalDirection =
+    pDart.mFirstFrictionalDirection;
+  pIgn.Get<F::ContactSurfaceMotionVelocity<P>>().contactSurfaceMotionVelocity =
+    pDart.mContactSurfaceMotionVelocity;
+
+  if (this->surfaceParamsCallback)
+  {
+    auto contactInternal = this->convertContact(_contact);
+    if (contactInternal)
+    {
+      this->surfaceParamsCallback(contactInternal.value(),
+                                  _numContactsOnCollisionObject, pIgn);
+
+      pDart.mFrictionCoeff = pIgn.Get<F::FrictionCoeff<P>>().frictionCoeff;
+      pDart.mSecondaryFrictionCoeff =
+        pIgn.Get<F::SecondaryFrictionCoeff<P>>().secondaryFrictionCoeff;
+      pDart.mSlipCompliance = pIgn.Get<F::SlipCompliance<P>>().slipCompliance;
+      pDart.mSecondarySlipCompliance =
+        pIgn.Get<F::SecondarySlipCompliance<P>>().secondarySlipCompliance;
+      pDart.mRestitutionCoeff =
+        pIgn.Get<F::RestitutionCoeff<P>>().restitutionCoeff;
+      pDart.mFirstFrictionalDirection =
+        pIgn.Get<F::FirstFrictionalDirection<P>>().firstFrictionalDirection;
+      pDart.mContactSurfaceMotionVelocity =
+        pIgn.Get<F::ContactSurfaceMotionVelocity<P>>().
+          contactSurfaceMotionVelocity;
+    }
+  }
+
+  this->lastIgnParams = pIgn;
+
+  return pDart;
+}
+
+dart::constraint::ContactConstraintPtr
+IgnContactSurfaceHandler::createConstraint(
+  dart::collision::Contact& _contact,
+  const size_t _numContactsOnCollisionObject,
+  const double _timeStep) const
+{
+  // this call sets this->lastIgnParams
+  auto constraint = dart::constraint::ContactSurfaceHandler::createConstraint(
+    _contact, _numContactsOnCollisionObject, _timeStep);
+
+  typedef SetContactJointPropertiesCallbackFeature F;
+  typedef FeaturePolicy3d P;
+  typename F::ContactSurfaceParams<P>& p = this->lastIgnParams;
+
+  if (this->lastIgnParams.Has<F::ErrorReductionParameter<P>>())
+    constraint->setErrorReductionParameter(
+      p.Get<F::ErrorReductionParameter<P>>().errorReductionParameter);
+
+  if (this->lastIgnParams.Has<F::MaxErrorAllowance<P>>())
+    constraint->setErrorAllowance(
+      p.Get<F::MaxErrorAllowance<P>>().maxErrorAllowance);
+
+  if (this->lastIgnParams.Has<F::MaxErrorReductionVelocity<P>>())
+    constraint->setMaxErrorReductionVelocity(
+      p.Get<F::MaxErrorReductionVelocity<P>>().maxErrorReductionVelocity);
+
+  if (this->lastIgnParams.Has<F::ConstraintForceMixing<P>>())
+    constraint->setConstraintForceMixing(
+      p.Get<F::ConstraintForceMixing<P>>().constraintForceMixing);
+
+  return constraint;
+}
+
 }
 }
 }

--- a/dartsim/src/SimulationFeatures.hh
+++ b/dartsim/src/SimulationFeatures.hh
@@ -21,8 +21,17 @@
 #include <vector>
 #include <ignition/physics/ForwardStep.hh>
 #include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/ContactJointProperties.hh>
 
 #include "Base.hh"
+
+namespace dart
+{
+namespace collision
+{
+class Contact;
+}
+}
 
 namespace ignition {
 namespace physics {
@@ -30,13 +39,22 @@ namespace dartsim {
 
 struct SimulationFeatureList : FeatureList<
   ForwardStep,
-  GetContactsFromLastStepFeature
+  GetContactsFromLastStepFeature,
+  SetContactJointPropertiesCallbackFeature
 > { };
+
+class SimulationFeaturesPrivate;
 
 class SimulationFeatures :
     public virtual Base,
     public virtual Implements3d<SimulationFeatureList>
 {
+  public: using GetContactsFromLastStepFeature::Implementation<FeaturePolicy3d>
+    ::ContactInternal;
+
+  public: SimulationFeatures();
+  public: ~SimulationFeatures() override;
+
   public: void WorldForwardStep(
       const Identity &_worldID,
       ForwardStep::Output &_h,
@@ -45,7 +63,20 @@ class SimulationFeatures :
 
   public: std::vector<ContactInternal> GetContactsFromLastStep(
       const Identity &_worldID) const override;
+
+  public: void AddContactJointPropertiesCallback(
+      const Identity &_worldID,
+      const std::string &_callbackID,
+      SurfaceParamsCallback _callback) override;
+
+  public: bool RemoveContactJointPropertiesCallback(
+      const Identity &_worldID, const std::string &_callbackID) override;
+
+  private: std::unique_ptr<SimulationFeaturesPrivate> dataPtr;
+  private: friend class SimulationFeaturesPrivate;
 };
+
+
 
 }
 }

--- a/include/ignition/physics/ContactJointProperties.hh
+++ b/include/ignition/physics/ContactJointProperties.hh
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef IGNITION_PHYSICS_CONTACTJOINTPROPERTIES_HH_
+#define IGNITION_PHYSICS_CONTACTJOINTPROPERTIES_HH_
+
+#include <vector>
+#include <ignition/physics/FeatureList.hh>
+#include <ignition/physics/ForwardStep.hh>
+#include <ignition/physics/Geometry.hh>
+#include <ignition/physics/GetContacts.hh>
+#include <ignition/physics/SpecifyData.hh>
+
+namespace ignition
+{
+namespace physics
+{
+/// \brief SetContactJointPropertiesCallbackFeature is a feature for setting the
+/// properties of a contact joint after it is created but before it affects the
+/// forward step.
+class IGNITION_PHYSICS_VISIBLE SetContactJointPropertiesCallbackFeature
+    : public virtual FeatureWithRequirements<ForwardStep>
+{
+  public: template <typename PolicyT> struct FrictionCoeff
+  {
+    typename PolicyT::Scalar frictionCoeff;
+  };
+
+  public: template <typename PolicyT> struct SecondaryFrictionCoeff
+  {
+    typename PolicyT::Scalar secondaryFrictionCoeff;
+  };
+
+  public: template <typename PolicyT> struct RollingFrictionCoeff
+  {
+    typename PolicyT::Scalar rollingFrictionCoeff;
+  };
+
+  public: template <typename PolicyT> struct SecondaryRollingFrictionCoeff
+  {
+    typename PolicyT::Scalar secondaryRollingFrictionCoeff;
+  };
+
+  public: template <typename PolicyT> struct NormalRollingFrictionCoeff
+  {
+    typename PolicyT::Scalar normalRollingFrictionCoeff;
+  };
+
+  public: template <typename PolicyT> struct SlipCompliance
+  {
+    typename PolicyT::Scalar slipCompliance;
+  };
+
+  public: template <typename PolicyT> struct SecondarySlipCompliance
+  {
+    typename PolicyT::Scalar secondarySlipCompliance;
+  };
+
+  public: template <typename PolicyT> struct RestitutionCoeff
+  {
+    typename PolicyT::Scalar restitutionCoeff;
+  };
+
+  public: template <typename PolicyT> struct FirstFrictionalDirection
+  {
+    typename FromPolicy<PolicyT>::template Use<Vector> firstFrictionalDirection;
+  };
+
+  public: template <typename PolicyT> struct ContactSurfaceMotionVelocity
+  {
+    typename FromPolicy<PolicyT>::template Use<Vector>
+      contactSurfaceMotionVelocity;
+  };
+
+  public: template <typename PolicyT> struct ErrorReductionParameter
+  {
+    typename PolicyT::Scalar errorReductionParameter;
+  };
+
+  public: template <typename PolicyT> struct MaxErrorReductionVelocity
+  {
+    typename PolicyT::Scalar maxErrorReductionVelocity;
+  };
+
+  public: template <typename PolicyT> struct MaxErrorAllowance
+  {
+    typename PolicyT::Scalar maxErrorAllowance;
+  };
+
+  public: template <typename PolicyT> struct ConstraintForceMixing
+  {
+    typename PolicyT::Scalar constraintForceMixing;
+  };
+
+  public: template <typename PolicyT> using ContactSurfaceParams =
+    SpecifyData<ExpectData<
+      FrictionCoeff<PolicyT>, SecondaryFrictionCoeff<PolicyT>,
+      RollingFrictionCoeff<PolicyT>, SecondaryRollingFrictionCoeff<PolicyT>,
+      NormalRollingFrictionCoeff<PolicyT>,
+      SlipCompliance<PolicyT>, SecondarySlipCompliance<PolicyT>,
+      RestitutionCoeff<PolicyT>,
+      FirstFrictionalDirection<PolicyT>,
+      ContactSurfaceMotionVelocity<PolicyT>,
+      ErrorReductionParameter<PolicyT>,
+      MaxErrorReductionVelocity<PolicyT>,
+      MaxErrorAllowance<PolicyT>,
+      ConstraintForceMixing<PolicyT> > >;
+
+  public: template <typename PolicyT, typename FeaturesT>
+  class World : public virtual Feature::World<PolicyT, FeaturesT>
+  {
+    public: using JointPtrType = JointPtr<PolicyT, FeaturesT>;
+
+    public: using ShapePtrType = typename GetContactsFromLastStepFeature
+      ::World<PolicyT, FeaturesT>::ShapePtrType;
+
+    public: using Contact = typename GetContactsFromLastStepFeature
+      ::World<PolicyT, FeaturesT>::Contact;
+
+    public: typedef std::function<
+        void(const Contact&, size_t, ContactSurfaceParams<PolicyT>&)
+      > SurfaceParamsCallback;
+
+    /// \brief Add the callback.
+    public: void AddContactJointPropertiesCallback(
+      const std::string &_callbackID, SurfaceParamsCallback _callback);
+
+    /// \brief Remove the callback.
+    public: bool RemoveContactJointPropertiesCallback(
+      const std::string &_callbackID);
+  };
+
+  public: template <typename PolicyT>
+  class Implementation : public virtual Feature::Implementation<PolicyT>
+  {
+    public: using ContactImpl = typename GetContactsFromLastStepFeature
+      ::Implementation<PolicyT>::ContactInternal;
+
+    public: typedef std::function<
+        void(const ContactImpl&, size_t, ContactSurfaceParams<PolicyT>&)
+      > SurfaceParamsCallback;
+
+    /// \brief Add the callback.
+    public: virtual void AddContactJointPropertiesCallback(
+      const Identity &_worldID,
+      const std::string &_callbackID,
+      SurfaceParamsCallback _callback) = 0;
+
+    /// \brief Remove the callback.
+    public: virtual bool RemoveContactJointPropertiesCallback(
+      const Identity &_worldID, const std::string &_callbackID) = 0;
+  };
+};
+
+}
+}
+
+#include "ignition/physics/detail/ContactJointProperties.hh"
+
+#endif /* end of include guard: IGNITION_PHYSICS_CONTACTJOINTPROPERTIES_HH_ */

--- a/include/ignition/physics/detail/ContactJointProperties.hh
+++ b/include/ignition/physics/detail/ContactJointProperties.hh
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef IGNITION_PHYSICS_DETAIL_CONTACTJOINTPROPERTIES_HH_
+#define IGNITION_PHYSICS_DETAIL_CONTACTJOINTPROPERTIES_HH_
+
+#include <utility>
+#include <vector>
+#include <ignition/physics/ContactJointProperties.hh>
+
+namespace ignition
+{
+namespace physics
+{
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void SetContactJointPropertiesCallbackFeature::World<PolicyT, FeaturesT>::
+  AddContactJointPropertiesCallback(
+    const std::string &_callbackID,
+    SurfaceParamsCallback _callback)
+{
+  using Impl = Implementation<PolicyT>;
+  using ContactInternal = typename Impl::ContactImpl;
+
+  auto pimpl = this->pimpl;
+  auto convertContact = [pimpl](const ContactInternal& _internal) -> Contact
+  {
+    using ContactPoint =
+      typename GetContactsFromLastStepFeature::World<PolicyT, FeaturesT>
+        ::ContactPoint;
+
+    ContactPoint contactPoint {
+      ShapePtrType(pimpl, _internal.collision1),
+      ShapePtrType(pimpl, _internal.collision2),
+      _internal.point
+    };
+
+    Contact contactOutput;
+    contactOutput.template Get<ContactPoint>() = std::move(contactPoint);
+
+    using ExtraContactData =
+      GetContactsFromLastStepFeature::ExtraContactDataT<PolicyT>;
+
+    auto *extraContactData =
+      _internal.extraData.template Query<ExtraContactData>();
+
+    if (extraContactData)
+    {
+      contactOutput.template Get<ExtraContactData>() =
+        std::move(*extraContactData);
+    }
+
+    return contactOutput;
+  };
+
+  typename Impl::SurfaceParamsCallback callbackInternal = nullptr;
+  if (_callback)
+  {
+    callbackInternal = [_callback, convertContact](
+      const typename Impl::ContactImpl &_contact,
+      const size_t _numContactsOnCollision,
+      ContactSurfaceParams<PolicyT> &_params)
+      {
+        _callback(convertContact(_contact), _numContactsOnCollision, _params);
+      };
+  }
+
+  this->template Interface<SetContactJointPropertiesCallbackFeature>()
+    ->AddContactJointPropertiesCallback(
+      this->identity, _callbackID, callbackInternal);
+}
+
+/////////////////////////////////////////////////
+template<typename PolicyT, typename FeaturesT>
+bool SetContactJointPropertiesCallbackFeature::World<PolicyT, FeaturesT>::
+  RemoveContactJointPropertiesCallback(const std::string& _callbackID)
+{
+  return this->template Interface<SetContactJointPropertiesCallbackFeature>()->
+    RemoveContactJointPropertiesCallback(this->identity, _callbackID);
+}
+
+}  // namespace physics
+}  // namespace ignition
+
+#endif


### PR DESCRIPTION
# 🎉 New feature

Closes #15, #82

## Summary
This PR adds support for registering callbacks that modify properties of all contact joints generated by the dynamics engine. Example implementation for DART is provided.

This feature might be highly useful for DARPA SubT virtual challenge to allow implementation of a proper track drivetrain.

## Test it
Testing is best done by running some of the ign-gazebo examples added in PR #TODO .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**