### PR TITLE
Add Gravity Feature, fix LinkFeatures_TEST

### DIFF
--- a/dartsim/src/KinematicsFeatures.cc
+++ b/dartsim/src/KinematicsFeatures.cc
@@ -30,12 +30,8 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
 {
   FrameData3d data;
 
-  // The feature system should never send us the world ID.
   if (_id.IsWorld())
   {
-    ignerr << "Given a FrameID belonging to the world. This should not be "
-           << "possible! Please report this bug!\n";
-    assert(false);
     return data;
   }
 

--- a/dartsim/src/KinematicsFeatures.cc
+++ b/dartsim/src/KinematicsFeatures.cc
@@ -30,8 +30,12 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
 {
   FrameData3d data;
 
+  // The feature system should never send us the world ID.
   if (_id.IsWorld())
   {
+    ignerr << "Given a FrameID belonging to the world. This should not be "
+           << "possible! Please report this bug!\n";
+    assert(false);
     return data;
   }
 

--- a/dartsim/src/LinkFeatures_TEST.cc
+++ b/dartsim/src/LinkFeatures_TEST.cc
@@ -79,13 +79,15 @@ TestWorldPtr LoadWorld(
 {
   sdf::Root root;
   const sdf::Errors errors = root.Load(_sdfFile);
-  EXPECT_TRUE(errors.empty());
+  EXPECT_TRUE(errors.empty()) << errors;
   const sdf::World *sdfWorld = root.WorldByIndex(0);
   // Make a copy of the world so we can set the gravity property
   // TODO(addisu) Add a world property feature to set gravity instead of this
   // hack
   sdf::World worldCopy;
   worldCopy.Load(sdfWorld->Element());
+  auto graphErrors = worldCopy.ValidateGraphs();
+  EXPECT_EQ(0u, graphErrors.size()) << graphErrors;
 
   worldCopy.SetGravity(math::eigen3::convert(_gravity));
   return _engine->ConstructWorld(worldCopy);

--- a/dartsim/src/LinkFeatures_TEST.cc
+++ b/dartsim/src/LinkFeatures_TEST.cc
@@ -125,7 +125,7 @@ TEST_F(LinkFeaturesFixture, LinkForceTorque)
   {
     AssertVectorApprox vectorPredicate(1e-10);
     EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d::Zero(),
-                        world->GetGravity(physics::FrameID::World()));
+                        world->GetGravity());
   }
 
   // Add a sphere

--- a/dartsim/src/LinkFeatures_TEST.cc
+++ b/dartsim/src/LinkFeatures_TEST.cc
@@ -122,6 +122,12 @@ TEST_F(LinkFeaturesFixture, LinkForceTorque)
 {
   auto world = LoadWorld(this->engine, TEST_WORLD_DIR "/empty.sdf",
                          Eigen::Vector3d::Zero());
+  {
+    AssertVectorApprox vectorPredicate(1e-10);
+    EXPECT_PRED_FORMAT2(vectorPredicate, Eigen::Vector3d::Zero(),
+                        world->GetGravity(physics::FrameID::World()));
+  }
+
   // Add a sphere
   sdf::Model modelSDF;
   modelSDF.SetName("sphere");

--- a/dartsim/src/ShapeFeatures_TEST.cc
+++ b/dartsim/src/ShapeFeatures_TEST.cc
@@ -98,25 +98,6 @@ class ShapeFeaturesFixture : public ::testing::Test
   protected: TestEnginePtr engine;
 };
 
-TestWorldPtr LoadWorld(
-    const TestEnginePtr &_engine,
-    const std::string &_sdfFile,
-    const Eigen::Vector3d &_gravity = Eigen::Vector3d{0, 0, -9.8})
-{
-  sdf::Root root;
-  const sdf::Errors errors = root.Load(_sdfFile);
-  EXPECT_TRUE(errors.empty());
-  const sdf::World *sdfWorld = root.WorldByIndex(0);
-  // Make a copy of the world so we can set the gravity property
-  // TODO(addisu) Add a world property feature to set gravity instead of this
-  // hack
-  sdf::World worldCopy;
-  worldCopy.Load(sdfWorld->Element());
-
-  worldCopy.SetGravity(math::eigen3::convert(_gravity));
-  return _engine->ConstructWorld(worldCopy);
-}
-
 // A predicate-formatter for asserting that two vectors are approximately equal.
 class AssertVectorApprox
 {

--- a/dartsim/src/WorldFeatures.cc
+++ b/dartsim/src/WorldFeatures.cc
@@ -81,6 +81,22 @@ const std::string &WorldFeatures::GetWorldCollisionDetector(const Identity &_id)
 }
 
 /////////////////////////////////////////////////
+void WorldFeatures::SetWorldGravity(
+    const Identity &_id, const LinearVectorType &_gravity)
+{
+  auto world = this->ReferenceInterface<dart::simulation::World>(_id);
+  world->setGravity(_gravity);
+}
+
+/////////////////////////////////////////////////
+WorldFeatures::LinearVectorType WorldFeatures::GetWorldGravity(
+    const Identity &_id) const
+{
+  auto world = this->ReferenceInterface<dart::simulation::World>(_id);
+  return world->getGravity();
+}
+
+/////////////////////////////////////////////////
 void WorldFeatures::SetWorldSolver(const Identity &_id,
     const std::string &_solver)
 {

--- a/dartsim/src/WorldFeatures.hh
+++ b/dartsim/src/WorldFeatures.hh
@@ -30,6 +30,7 @@ namespace dartsim {
 
 struct WorldFeatureList : FeatureList<
   CollisionDetector,
+  Gravity,
   Solver
 > { };
 
@@ -44,6 +45,13 @@ class WorldFeatures :
   // Documentation inherited
   public: const std::string &GetWorldCollisionDetector(const Identity &_id)
       const override;
+
+  // Documentation inherited
+  public: void SetWorldGravity(
+      const Identity &_id, const LinearVectorType &_gravity) override;
+
+  // Documentation inherited
+  public: LinearVectorType GetWorldGravity(const Identity &_id) const override;
 
   // Documentation inherited
   public: void SetWorldSolver(const Identity &_id, const std::string &_solver)

--- a/dartsim/src/WorldFeatures_TEST.cc
+++ b/dartsim/src/WorldFeatures_TEST.cc
@@ -35,6 +35,8 @@
 
 struct TestFeatureList : ignition::physics::FeatureList<
     ignition::physics::CollisionDetector,
+    ignition::physics::Gravity,
+    ignition::physics::LinkFrameSemantics,
     ignition::physics::Solver,
     ignition::physics::ForwardStep,
     ignition::physics::sdf::ConstructSdfWorld,
@@ -45,6 +47,29 @@ using namespace ignition;
 
 using TestEnginePtr = physics::Engine3dPtr<TestFeatureList>;
 using TestWorldPtr = physics::World3dPtr<TestFeatureList>;
+
+// A predicate-formatter for asserting that two vectors are approximately equal.
+class AssertVectorApprox
+{
+  public: explicit AssertVectorApprox(double _tol = 1e-6) : tol(_tol)
+  {
+  }
+
+  public: ::testing::AssertionResult operator()(
+              const char *_mExpr, const char *_nExpr, Eigen::Vector3d _m,
+              Eigen::Vector3d _n)
+  {
+    if (ignition::physics::test::Equal(_m, _n, this->tol))
+      return ::testing::AssertionSuccess();
+
+    return ::testing::AssertionFailure()
+           << _mExpr << " and " << _nExpr << " ([" << _m.transpose()
+           << "] and [" << _n.transpose() << "]"
+           << ") are not equal";
+  }
+
+  private: double tol;
+};
 
 //////////////////////////////////////////////////
 class WorldFeaturesFixture : public ::testing::Test
@@ -96,6 +121,76 @@ TEST_F(WorldFeaturesFixture, CollisionDetector)
 
   world->SetCollisionDetector("dart");
   EXPECT_EQ("dart", world->GetCollisionDetector());
+}
+
+//////////////////////////////////////////////////
+TEST_F(WorldFeaturesFixture, Gravity)
+{
+  auto world = LoadWorld(this->engine, TEST_WORLD_DIR "/falling.world");
+  ASSERT_NE(nullptr, world);
+
+  // Check default gravity value
+  AssertVectorApprox vectorPredicate10(1e-10);
+  EXPECT_PRED_FORMAT2(vectorPredicate10, Eigen::Vector3d(0, 0, -9.8),
+                      world->GetGravity());
+
+  auto model = world->GetModel("sphere");
+  ASSERT_NE(nullptr, model);
+
+  auto link = model->GetLink(0);
+  ASSERT_NE(nullptr, link);
+
+  // initial link pose
+  const Eigen::Vector3d initialLinkPosition(0, 0, 2);
+  {
+    auto pos = link->FrameDataRelativeToWorld().pose.translation();
+    EXPECT_PRED_FORMAT2(vectorPredicate10,
+                        initialLinkPosition,
+                        pos);
+  }
+
+  auto linkFrameID = link->GetFrameID();
+
+  // Get default gravity in link frame, which is pitched by pi/4
+  EXPECT_PRED_FORMAT2(vectorPredicate10,
+                      Eigen::Vector3d(6.92964645563, 0, -6.92964645563),
+                      world->GetGravity(linkFrameID));
+
+  // set gravity along X axis of linked frame, which is pitched by pi/4
+  world->SetGravity(Eigen::Vector3d(1.4142135624, 0, 0), linkFrameID);
+
+  EXPECT_PRED_FORMAT2(vectorPredicate10,
+                      Eigen::Vector3d(1, 0, -1),
+                      world->GetGravity());
+
+  // test other SetGravity API
+  // set gravity along Z axis of linked frame, which is pitched by pi/4
+  physics::RelativeForce3d relativeGravity(
+      linkFrameID, Eigen::Vector3d(0, 0, 1.4142135624));
+  world->SetGravity(relativeGravity);
+
+  EXPECT_PRED_FORMAT2(vectorPredicate10,
+                      Eigen::Vector3d(1, 0, 1),
+                      world->GetGravity());
+
+  // Confirm that changed gravity direction affects pose of link
+  ignition::physics::ForwardStep::Input input;
+  ignition::physics::ForwardStep::State state;
+  ignition::physics::ForwardStep::Output output;
+
+  const size_t numSteps = 1000;
+  for (size_t i = 0; i < numSteps; ++i)
+  {
+    world->Step(output, state, input);
+  }
+
+  AssertVectorApprox vectorPredicate3(1e-3);
+  {
+    auto pos = link->FrameDataRelativeToWorld().pose.translation();
+    EXPECT_PRED_FORMAT2(vectorPredicate3,
+                        Eigen::Vector3d(0.5, 0, 2.5),
+                        pos);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/include/ignition/physics/World.hh
+++ b/include/ignition/physics/World.hh
@@ -78,15 +78,14 @@ namespace ignition
         public: using LinearVectorType =
             typename FromPolicy<PolicyT>::template Use<LinearVector>;
 
-        public: using RelativeGravityType = RelativeQuantity<
-            LinearVectorType, PolicyT::Dim,
-            detail::VectorSpace<typename PolicyT::Scalar, PolicyT::Dim>>;
+        public: using RelativeForceType =
+            typename FromPolicy<PolicyT>::template Use<RelativeForce>;
 
         /// \brief Set the World gravity vector.
         /// \param[in] _gravity The desired gravity as a Relative Gravity
         /// (a quantity that contains information about the coordinates
         /// in which it is expressed).
-        public: void SetGravity(const RelativeGravityType &_gravity);
+        public: void SetGravity(const RelativeForceType &_gravity);
 
         /// \brief Set the World gravity vector. Optionally, you may specify
         /// the frame whose coordinates are used to express the gravity vector.

--- a/include/ignition/physics/World.hh
+++ b/include/ignition/physics/World.hh
@@ -83,7 +83,7 @@ namespace ignition
       {
         /// \brief Implementation API for setting the solver.
         /// \param[in] _id Identity of the world.
-        /// \param[in] _collisionDetector Name of solver.
+        /// \param[in] _solver Name of solver.
         public: virtual void SetWorldSolver(
             const Identity &_id, const std::string &_solver) = 0;
 

--- a/include/ignition/physics/World.hh
+++ b/include/ignition/physics/World.hh
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <ignition/physics/FeatureList.hh>
+#include <ignition/physics/FrameSemantics.hh>
 
 namespace ignition
 {
@@ -57,6 +58,81 @@ namespace ignition
         /// \param[in] _id Identity of the world.
         /// \return Name of collision detector.
         public: virtual const std::string &GetWorldCollisionDetector(
+            const Identity &_id) const = 0;
+      };
+    };
+
+    /////////////////////////////////////////////////
+    using GravityRequiredFeatures = FeatureList<FrameSemantics>;
+
+    /////////////////////////////////////////////////
+    /// \brief Get and set the World's gravity vector in a specified frame.
+    class IGNITION_PHYSICS_VISIBLE Gravity
+        : public virtual
+          FeatureWithRequirements<GravityRequiredFeatures>
+    {
+      /// \brief The World API for getting and setting the gravity vector.
+      public: template <typename PolicyT, typename FeaturesT>
+      class World : public virtual Feature::World<PolicyT, FeaturesT>
+      {
+        public: using LinearVectorType =
+            typename FromPolicy<PolicyT>::template Use<LinearVector>;
+
+        public: using RelativeGravityType = RelativeQuantity<
+            LinearVectorType, PolicyT::Dim,
+            detail::VectorSpace<typename PolicyT::Scalar, PolicyT::Dim>>;
+
+        /// \brief Set the World gravity vector.
+        /// \param[in] _gravity The desired gravity as a Relative Gravity
+        /// (a quantity that contains information about the coordinates
+        /// in which it is expressed).
+        public: void SetGravity(const RelativeGravityType &_gravity);
+
+        /// \brief Set the World gravity vector. Optionally, you may specify
+        /// the frame whose coordinates are used to express the gravity vector.
+        /// The World frame is used as a default if no frame is specified.
+        /// \param[in] _gravity Gravity vector.
+        /// \param[in] _inCoordinatesOf Frame whose coordinates are used
+        /// to express _gravity.
+        public: void SetGravity(
+            const LinearVectorType &_gravity,
+            const FrameID &_forceInCoordinatesOf = FrameID::World());
+
+        /// \brief Get the World gravity vector as a Relative Gravity
+        /// (a quantity that contains information about the coordinates
+        /// in which it is expressed).
+        /// \return Relative Gravity vector.
+        public: RelativeGravityType GetGravity() const;
+
+        /// \brief Get the World gravity vector. Optionally, you may specify
+        /// the frame whose coordinates are used to express the gravity vector.
+        /// The World frame is used as a default if no frame is specified.
+        /// \param[in] _inCoordinatesOf Frame whose coordinates are used
+        /// to express _gravity.
+        /// \return Gravity vector in corrdinates of _inCoordinatesOf.
+        public: LinearVectorType GetGravity(
+            const FrameID &_forceInCoordinatesOf = FrameID::World()) const;
+      };
+
+      /// \private The implementation API for the gravity.
+      public: template <typename PolicyT>
+      class Implementation : public virtual Feature::Implementation<PolicyT>
+      {
+        public: using LinearVectorType =
+            typename FromPolicy<PolicyT>::template Use<LinearVector>;
+
+        /// \brief Implementation API for setting the gravity vector, which is
+        /// expressed in the World frame..
+        /// \param[in] _id Identity of the world.
+        /// \param[in] _gravity Name of gravity.
+        public: virtual void SetWorldGravity(
+            const Identity &_id, const LinearVectorType &_gravity) = 0;
+
+        /// \brief Implementation API for getting the gravity expressed in the
+        /// world frame.
+        /// \param[in] _id Identity of the world.
+        /// \return Name of gravity.
+        public: virtual LinearVectorType GetWorldGravity(
             const Identity &_id) const = 0;
       };
     };

--- a/include/ignition/physics/World.hh
+++ b/include/ignition/physics/World.hh
@@ -124,14 +124,14 @@ namespace ignition
         /// \brief Implementation API for setting the gravity vector, which is
         /// expressed in the World frame..
         /// \param[in] _id Identity of the world.
-        /// \param[in] _gravity Name of gravity.
+        /// \param[in] _gravity Value of gravity.
         public: virtual void SetWorldGravity(
             const Identity &_id, const LinearVectorType &_gravity) = 0;
 
         /// \brief Implementation API for getting the gravity expressed in the
         /// world frame.
         /// \param[in] _id Identity of the world.
-        /// \return Name of gravity.
+        /// \return Value of gravity.
         public: virtual LinearVectorType GetWorldGravity(
             const Identity &_id) const = 0;
       };

--- a/include/ignition/physics/World.hh
+++ b/include/ignition/physics/World.hh
@@ -98,12 +98,6 @@ namespace ignition
             const LinearVectorType &_gravity,
             const FrameID &_forceInCoordinatesOf = FrameID::World());
 
-        /// \brief Get the World gravity vector as a Relative Gravity
-        /// (a quantity that contains information about the coordinates
-        /// in which it is expressed).
-        /// \return Relative Gravity vector.
-        public: RelativeGravityType GetGravity() const;
-
         /// \brief Get the World gravity vector. Optionally, you may specify
         /// the frame whose coordinates are used to express the gravity vector.
         /// The World frame is used as a default if no frame is specified.

--- a/include/ignition/physics/detail/FrameSemantics.hh
+++ b/include/ignition/physics/detail/FrameSemantics.hh
@@ -57,8 +57,16 @@ namespace ignition
           }
 
           q = _quantity.RelativeToParent();
-          currentCoordinates = _impl.FrameDataRelativeToWorld(
-                _relativeTo).pose.linear();
+          if (_relativeTo.IsWorld())
+          {
+            // The World Frame has all zero fields
+            currentCoordinates = RotationType::Identity();
+          }
+          else
+          {
+            currentCoordinates = _impl.FrameDataRelativeToWorld(
+                  _relativeTo).pose.linear();
+          }
         }
         else
         {

--- a/include/ignition/physics/detail/World.hh
+++ b/include/ignition/physics/detail/World.hh
@@ -47,7 +47,7 @@ const std::string &CollisionDetector::World<PolicyT, FeaturesT>::
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
 void Gravity::World<PolicyT, FeaturesT>::SetGravity(
-    const RelativeGravityType &_gravity)
+    const RelativeForceType &_gravity)
 {
   // Resolve to world coordinates
   auto &impl = *this->template Interface<FrameSemantics>();
@@ -70,10 +70,10 @@ void Gravity::World<PolicyT, FeaturesT>::SetGravity(
     this->template Interface<Gravity>()
         ->SetWorldGravity(this->identity, _gravity);
   }
-  // Otherwise make a RelativeGravity object and call the other API
+  // Otherwise make a RelativeForce object and call the other API
   else
   {
-    RelativeGravityType gravityInRef(_inCoordinatesOf, _gravity);
+    RelativeForceType gravityInRef(_inCoordinatesOf, _gravity);
     this->SetGravity(gravityInRef);
   }
 }
@@ -94,7 +94,7 @@ auto Gravity::World<PolicyT, FeaturesT>::GetGravity(
 
   // Otherwise resolve to proper frame
   auto &impl = *this->template Interface<FrameSemantics>();
-  RelativeGravityType gravityInRef(FrameID::World(), gravityInWorld);
+  RelativeForceType gravityInRef(FrameID::World(), gravityInWorld);
   return detail::Resolve(impl, gravityInRef, FrameID::World(),
                          _inCoordinatesOf);
 }

--- a/include/ignition/physics/detail/World.hh
+++ b/include/ignition/physics/detail/World.hh
@@ -46,6 +46,72 @@ const std::string &CollisionDetector::World<PolicyT, FeaturesT>::
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
+void Gravity::World<PolicyT, FeaturesT>::SetGravity(
+    const RelativeGravityType &_gravity)
+{
+  // Resolve to world coordinates
+  auto &impl = *this->template Interface<FrameSemantics>();
+  auto gravityInWorld =
+      detail::Resolve(impl, _gravity, FrameID::World(), FrameID::World());
+
+  this->template Interface<Gravity>()
+      ->SetWorldGravity(this->identity, gravityInWorld);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+void Gravity::World<PolicyT, FeaturesT>::SetGravity(
+    const LinearVectorType &_gravity,
+    const FrameID &_inCoordinatesOf)
+{
+  // Call SetWorldGravity directly if using world coordinates
+  if (_inCoordinatesOf == FrameID::World())
+  {
+    this->template Interface<Gravity>()
+        ->SetWorldGravity(this->identity, _gravity);
+  }
+  // Otherwise make a RelativeGravity object and call the other API
+  else
+  {
+    RelativeGravityType gravityInRef(_inCoordinatesOf, _gravity);
+    this->SetGravity(gravityInRef);
+  }
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+auto Gravity::World<PolicyT, FeaturesT>::GetGravity() const
+    -> RelativeGravityType
+{
+  return RelativeGravityType(
+      FrameID::World(),
+      this->template Interface<Gravity>()
+          ->GetWorldGravity(this->identity));
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
+auto Gravity::World<PolicyT, FeaturesT>::GetGravity(
+    const FrameID &_inCoordinatesOf) const
+    -> LinearVectorType
+{
+  // Return quickly if using world coordinates
+  auto gravityInWorld = this->template Interface<Gravity>()
+                            ->GetWorldGravity(this->identity);
+  if (_inCoordinatesOf == FrameID::World())
+  {
+    return gravityInWorld;
+  }
+
+  // Otherwise resolve to proper frame
+  auto &impl = *this->template Interface<FrameSemantics>();
+  RelativeGravityType gravityInRef(FrameID::World(), gravityInWorld);
+  return detail::Resolve(impl, gravityInRef, FrameID::World(),
+                         _inCoordinatesOf);
+}
+
+/////////////////////////////////////////////////
+template <typename PolicyT, typename FeaturesT>
 void Solver::World<PolicyT, FeaturesT>::SetSolver(
     const std::string &_solver)
 {

--- a/include/ignition/physics/detail/World.hh
+++ b/include/ignition/physics/detail/World.hh
@@ -80,17 +80,6 @@ void Gravity::World<PolicyT, FeaturesT>::SetGravity(
 
 /////////////////////////////////////////////////
 template <typename PolicyT, typename FeaturesT>
-auto Gravity::World<PolicyT, FeaturesT>::GetGravity() const
-    -> RelativeGravityType
-{
-  return RelativeGravityType(
-      FrameID::World(),
-      this->template Interface<Gravity>()
-          ->GetWorldGravity(this->identity));
-}
-
-/////////////////////////////////////////////////
-template <typename PolicyT, typename FeaturesT>
 auto Gravity::World<PolicyT, FeaturesT>::GetGravity(
     const FrameID &_inCoordinatesOf) const
     -> LinearVectorType


### PR DESCRIPTION
# 🎉 New feature

This adds a feature for getting and setting the gravity vector in a `World`. This was motivated by a failing test in #261.

## Summary

The [LinkFeatures_TEST](https://github.com/ignitionrobotics/ign-physics/blob/ignition-physics4_4.1.0/dartsim/src/LinkFeatures_TEST.cc#L84-L91) currently loads an `sdf::World` object then copies it in order to modify the `<gravity/>` SDFormat element, with a comment noting "// TODO Add a world property feature to set gravity instead of this hack". In `ignition-physics3` and earlier, this was a useful hack, but it doesn't work in `ignition-physics4` due to an internal change in `libsdformat11`. I've illustrated the problem by adding some failing test expectations in e270f65 that call `sdf::World::ValidateGraphs`. Loading the `sdf::World` from an `sdf::ElementPtr` does not work anymore; you have to load an `sdf::Root` in order for the `FrameAttachedToGraph` and `PoseRelativeToGraph` to be properly loaded. I believe this is also related to the test failures observed in #261.

To fix the issue, I've added `World::GetGravity` and `World::SetGravity` APIs in a new `Gravity` Feature in `World.hh` (
94048ea). The APIs use `FrameSemantics.hh` so you can specify the `FrameID` for the coordinates in which the gravity vector is specified. I then updated the `LoadWorld` function in `LinkFeatures_TEST` in ec232ac so it can load the world properly. I removed the `LoadWorld` function from `ShapeFeatures_TEST` in 573f001 since it has the same flaw but is unused.

## Test it

Compile the code as of e270f65 and observe the failure of `UNIT_LinkFeatures_TEST`, and then observe that the test passes with the tip of the branch.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
