### PR TITLE
Make ignition-physics CMake config files relocatable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,8 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
     ${ignition-math${IGN_MATH_VER}_LIBRARIES}
     ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
-    ignition-plugin${IGN_PLUGIN_VER}::register)
-
-target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}
-  SYSTEM PUBLIC
-    ${EIGEN3_INCLUDE_DIRS})
+    ignition-plugin${IGN_PLUGIN_VER}::register
+    Eigen3::Eigen)
 
 ign_build_tests(
   TYPE UNIT


### PR DESCRIPTION
# 🦟 Bug fix
## Summary

Avoid to use `EIGEN3_INCLUDE_DIRS` variable with `target_include_directories` command, as this result in hardcoding the `EIGEN3_INCLUDE_DIRS` value in the ignition-physics build machine, that could be different from the location where the Eigen3 include directories are installed in the machine that is consuming the ignition-physics CMake package. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
