### PR TITLE
Fix TPE Link velocity not being updated and Model velocity not having any effect.

### DIFF
--- a/tpe/plugin/src/KinematicsFeatures.cc
+++ b/tpe/plugin/src/KinematicsFeatures.cc
@@ -56,6 +56,13 @@ FrameData3d KinematicsFeatures::FrameDataRelativeToWorld(
     {
       auto link = linkIt->second->link;
       data.pose = math::eigen3::convert(link->GetWorldPose());
+      auto modelId = link->GetParent()->GetId();
+      auto modelPtr = this->models.find(modelId)->second->model;
+      math::Pose3d parentWorldPose = modelPtr->GetWorldPose();
+      data.linearVelocity = math::eigen3::convert(parentWorldPose.Rot().Inverse() *
+          link->GetLinearVelocity() + modelPtr->GetLinearVelocity());
+      data.angularVelocity = math::eigen3::convert(parentWorldPose.Rot().Inverse() *
+          link->GetAngularVelocity() + modelPtr->GetAngularVelocity());
     }
     else
     {

--- a/tpe/plugin/src/SimulationFeatures.cc
+++ b/tpe/plugin/src/SimulationFeatures.cc
@@ -72,6 +72,8 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
   _changedPoses.entries.reserve(this->links.size());
 
   std::unordered_map<std::size_t, math::Pose3d> newPoses;
+  // Store the updated links to avoid duplicated entries in _changedPoses
+  std::unordered_set<std::size_t> updatedLinkIds;
 
   for (const auto &[id, info] : this->links)
   {
@@ -79,11 +81,11 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
     if (info)
     {
       const auto nextPose = info->link->GetPose();
-      auto iter = this->prevLinkPoses.find(id);
+      auto iter = this->prevEntityPoses.find(id);
 
       // If the link's pose is new or has changed, save this new pose and
       // add it to the output poses. Otherwise, keep the existing link pose
-      if ((iter == this->prevLinkPoses.end()) ||
+      if ((iter == this->prevEntityPoses.end()) ||
           !iter->second.Pos().Equal(nextPose.Pos(), 1e-6) ||
           !iter->second.Rot().Equal(nextPose.Rot(), 1e-6))
       {
@@ -91,6 +93,7 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
         wp.pose = nextPose;
         wp.body = id;
         _changedPoses.entries.push_back(wp);
+        updatedLinkIds.insert(id);
         newPoses[id] = nextPose;
       }
       else
@@ -108,22 +111,28 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
       if (info->model->GetStatic())
         continue;
       const auto nextPose = info->model->GetPose();
-      // Note, now prevLinkPoses also containes prevModelPoses
+      // Note, now prevEntityPoses also contains prevModelPoses
       // Data structure has been kept to avoid breaking ABI
-      auto iter = this->prevLinkPoses.find(id);
+      auto iter = this->prevEntityPoses.find(id);
 
       // If the models's pose is new or has changed, calculate and add all
       // the children links' poses to the output poses
-      if ((iter == this->prevLinkPoses.end()) ||
+      if ((iter == this->prevEntityPoses.end()) ||
           !iter->second.Pos().Equal(nextPose.Pos(), 1e-6) ||
           !iter->second.Rot().Equal(nextPose.Rot(), 1e-6))
       {
         for (const auto &linkEnt : info->model->GetChildren())
         {
-          WorldPose wp;
-          wp.pose = linkEnt.second->GetPose();
-          wp.body = linkEnt.second->GetId();
-          _changedPoses.entries.push_back(wp);
+          // Avoid pushing if the link was already updated in the previous loop
+          auto linkId = linkEnt.second->GetId();
+          if (updatedLinkIds.find(linkId) == updatedLinkIds.end())
+          {
+            WorldPose wp;
+            wp.pose = linkEnt.second->GetPose();
+            wp.body = linkId;
+            _changedPoses.entries.push_back(wp);
+            updatedLinkIds.insert(linkId);
+          }
           newPoses[id] = linkEnt.second->GetPose();
         }
       }
@@ -133,9 +142,9 @@ void SimulationFeatures::Write(ChangedWorldPoses &_changedPoses) const
   }
 
   // Save the new poses so that they can be used to check for updates in the
-  // next iteration. Re-setting this->prevLinkPoses with the contents of
+  // next iteration. Re-setting this->prevEntityPoses with the contents of
   // newPoses ensures that we aren't caching data for links that were removed
-  this->prevLinkPoses = std::move(newPoses);
+  this->prevEntityPoses = std::move(newPoses);
 }
 
 std::vector<SimulationFeatures::ContactInternal>

--- a/tpe/plugin/src/SimulationFeatures.hh
+++ b/tpe/plugin/src/SimulationFeatures.hh
@@ -61,9 +61,10 @@ class SimulationFeatures :
   /// \return Collision entity
   private: tpelib::Entity &GetModelCollision(std::size_t _id) const;
 
-  /// \brief link poses from the most recent pose change/update.
-  /// The key is the link's ID, and the value is the link's pose
-  private: mutable std::unordered_map<std::size_t, math::Pose3d> prevLinkPoses;
+  /// \brief entity poses from the most recent pose change/update.
+  /// The key is the entity's ID, and the value is the entity's pose
+  private: mutable std::unordered_map<std::size_t, math::Pose3d>
+     prevEntityPoses;
 };
 
 }

--- a/tpe/plugin/src/SimulationFeatures_TEST.cc
+++ b/tpe/plugin/src/SimulationFeatures_TEST.cc
@@ -450,17 +450,28 @@ TEST_P(SimulationFeatures_TEST, FreeGroup)
     auto freeGroupLink = link->FindFreeGroup();
     ASSERT_NE(nullptr, freeGroupLink);
 
+    StepWorld(world, true);
+
     freeGroup->SetWorldPose(
       ignition::math::eigen3::convert(
         ignition::math::Pose3d(0, 0, 2, 0, 0, 0)));
     freeGroup->SetWorldLinearVelocity(
-      ignition::math::eigen3::convert(ignition::math::Vector3d(0.5, 0, 0.1)));
+      ignition::math::eigen3::convert(ignition::math::Vector3d(0.1, 0.2, 0.3)));
     freeGroup->SetWorldAngularVelocity(
-      ignition::math::eigen3::convert(ignition::math::Vector3d(0.1, 0.2, 0)));
+      ignition::math::eigen3::convert(ignition::math::Vector3d(0.4, 0.5, 0.6)));
 
     auto frameData = model->GetLink(0)->FrameDataRelativeToWorld();
     EXPECT_EQ(ignition::math::Pose3d(0, 0, 2, 0, 0, 0),
               ignition::math::eigen3::convert(frameData.pose));
+
+    // Step the world
+    StepWorld(world, false);
+    // Check that the first link's velocities are updated
+    frameData = model->GetLink(0)->FrameDataRelativeToWorld();
+    EXPECT_EQ(ignition::math::Vector3d(0.1, 0.2, 0.3),
+              ignition::math::eigen3::convert(frameData.linearVelocity));
+    EXPECT_EQ(ignition::math::Vector3d(0.4, 0.5, 0.6),
+              ignition::math::eigen3::convert(frameData.angularVelocity));
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR fixes two separate issues regarding TPE:

The first one was likely introduced in the performance optimization PRs (such as #223). Velocity control of models using TPE now doesn't work anymore. To try it out compare the results of:
`ign gazebo /home/luca/ws_edifice/src/ign-gazebo/examples/worlds/velocity_control.sdf --physics-engine ignition-physics-tpe-plugin`
and
`ign gazebo /home/luca/ws_edifice/src/ign-gazebo/examples/worlds/velocity_control.sdf `
The green vehicle does not move under TPE.
My suspicion is that it is due to the fact that instead of sending all the links we now send only updated links and since the velocity is updated at the model level the links themselves are not updated.
The fix I came up with involves iterating over the models in the update step (skipping static models) and, when a model had its pose updated, add all its links to the output of `Step` so that Gazebo will correctly update them. This fix makes the example work again, I'm not sure about the performance overhead but hopefully because of the static check it shouldn't be too large for worlds with a lot of static objects.

The second issue has probably always been there. As part of [ign-gazebo #966](https://github.com/ignitionrobotics/ign-gazebo/issues/966), I have been trying to implement velocity control using `LinearVelocity` and `AngularVelocity` components, however it seems velocity was always read as 0 in TPE.
I noticed that in [KinematicsFeature](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics4/tpe/plugin/src/KinematicsFeatures.cc#L48-L49) velocity is updated for models. However, in the physics update step we only send link information, not model information.
As a consequence I decided to also calculate and send Link velocity information in the global frame, this fixes the ign-gazebo issue (that can be tested with the `luca/linVelCmdTest` in `ign-gazebo`), as far as TPE is concerned.

I only managed to add a test for the second issue, a simple velocity loopback that fails before the PR and succeeds afterwards, I think the test for the last issue is a bit more complex since it involves the data being passed to `ign-gazebo`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**