### PR TITLE
Prepare for 5.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 2.8.0 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,46 @@
 
 ### Ignition Physics 5.0.0 (20XX-XX-XX)
 
+1. Add GetJointTransmittedWrench feature
+    * [Pull request #283](https://github.com/ignitionrobotics/ign-physics/pull/283)
+
+1. [dartsim] Add support for joint frame semantics
+    * [Pull request #288](https://github.com/ignitionrobotics/ign-physics/pull/288)
+
+1. Fix TPE Link velocity not being updated and Model velocity not having any effect.
+    * [Pull request #289](https://github.com/ignitionrobotics/ign-physics/pull/289)
+
+1. 👩‍🌾 Remove bitbucket-pipelines.yml
+    * [Pull request #287](https://github.com/ignitionrobotics/ign-physics/pull/287)
+
+1. Make ignition-physics CMake config files relocatable
+    * [Pull request #282](https://github.com/ignitionrobotics/ign-physics/pull/282)
+
+1. Added DART feature for setting joint limits dynamically.
+    * [Pull request #260](https://github.com/ignitionrobotics/ign-physics/pull/260)
+
+1. Remove outdated comment #280
+    * [Pull request #280](https://github.com/ignitionrobotics/ign-physics/pull/280)
+
+1. Remove use of deprecated function sdf::JointAxis::InitialPosition
+    * [Pull request #276](https://github.com/ignitionrobotics/ign-physics/pull/276)
+
+1. Clean up functions that trigger GCC9 warnings
+    * [Pull request #261](https://github.com/ignitionrobotics/ign-physics/pull/261)
+
+1. Forward merges
+    * [Pull request #292](https://github.com/ignitionrobotics/ign-physics/pull/292)
+    * [Pull request #291](https://github.com/ignitionrobotics/ign-physics/pull/291)
+    * [Pull request #290](https://github.com/ignitionrobotics/ign-physics/pull/290)
+    * [Pull request #272](https://github.com/ignitionrobotics/ign-physics/pull/272)
+    * [Pull request #254](https://github.com/ignitionrobotics/ign-physics/pull/254)
+
+1. Bumps in fortress : ign-physics5
+    * [Pull request #246](https://github.com/ignitionrobotics/ign-physics/pull/246)
+
+1. Bump main to 5.0.0~pre1
+    * [Pull request #245](https://github.com/ignitionrobotics/ign-physics/pull/245)
+
 ## Ignition Physics 4.x
 
 ### Ignition Physics 4.x.x (20XX-XX-XX)


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.0.0~pre1 release.

Comparison to 4.2.0: https://github.com/ignitionrobotics/ign-physics/compare/ignition-physics4_...main

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/ignitionrobotics/ign-gazebo/pull/989/

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
