### PR TITLE
Remove unused ign_auto_headers.hh.in

### DIFF
--- a/include/ignition/physics/ign_auto_headers.hh.in
+++ b/include/ignition/physics/ign_auto_headers.hh.in
@@ -1,3 +1,0 @@
-// Automatically generated
-#include <ignition/${IG_PROJECT_NAME}/config.hh>
-${ign_headers}


### PR DESCRIPTION
# 🦟 Bug fix

Removes an unused file

## Summary

The [ign_auto_headers.hh.in](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/cmake/ign_auto_headers.hh.in) is provided by ign-cmake, but for some reason, this package has an old, unused copy in the source code. We can just remove it. Many other `ign-` packages have this as well, so it can be removed from there when convenient.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
