### PR TITLE
Prepare for 2.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 2.8.0 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX pre1)
+ign_configure_project(VERSION_SUFFIX)
 
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 
 ### Ignition Physics 2.x.x (20XX-XX-XX)
 
-### Ignition Physics 2.5.0 (2021-10-28)
+### Ignition Physics 2.5.0 (2021-11-09)
+
+1. Remove unused ign_auto_headers.hh.in
+    * [Pull request #305](https://github.com/ignitionrobotics/ign-physics/pull/305)
 
 1. Added DART feature for setting joint limits dynamically.
     * [Pull request #260](https://github.com/ignitionrobotics/ign-physics/pull/260)


### PR DESCRIPTION
# 🎈 Release

Preparation for 2.5.0 release.

Comparison to 2.5.0-pre1: https://github.com/ignitionrobotics/ign-physics/compare/ignition-physics2_2.5.0-pre1...ign-physics2

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/ignitionrobotics/ign-gazebo/pull/847, https://github.com/ignitionrobotics/ign-gazebo/pull/869

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
~- [ ] Updated migration guide (as needed)~
- [x] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
