### PR TITLE
Fix tutorials broken ref links, snippets, image widths

### DIFF
--- a/dartsim/include/ignition/physics/dartsim/World.hh
+++ b/dartsim/include/ignition/physics/dartsim/World.hh
@@ -45,6 +45,7 @@ class RetrieveWorld : public virtual Feature
 };
 
 /////////////////////////////////////////////////
+//! [feature template]
 template <typename PolicyT, typename FeaturesT>
 dart::simulation::WorldPtr RetrieveWorld::World<PolicyT, FeaturesT>
 ::GetDartsimWorld()
@@ -52,6 +53,7 @@ dart::simulation::WorldPtr RetrieveWorld::World<PolicyT, FeaturesT>
   return this->template Interface<RetrieveWorld>()
       ->GetDartsimWorld(this->identity);
 }
+//! [feature template]
 
 }
 }

--- a/dartsim/src/CustomFeatures.cc
+++ b/dartsim/src/CustomFeatures.cc
@@ -22,11 +22,13 @@ namespace physics {
 namespace dartsim {
 
 /////////////////////////////////////////////////
+//! [implementation]
 dart::simulation::WorldPtr CustomFeatures::GetDartsimWorld(
     const Identity &_worldID)
 {
   return this->worlds.at(_worldID);
 }
+//! [implementation]
 
 }
 }

--- a/dartsim/src/CustomFeatures.hh
+++ b/dartsim/src/CustomFeatures.hh
@@ -28,9 +28,11 @@ namespace ignition {
 namespace physics {
 namespace dartsim {
 
+//! [add to list]
 using CustomFeatureList = FeatureList<
   RetrieveWorld
 >;
+//! [add to list]
 
 class CustomFeatures :
     public virtual Base,

--- a/tutorials/05_plugin_loading.md
+++ b/tutorials/05_plugin_loading.md
@@ -13,11 +13,11 @@ plugin using \ref ignition::physics "Ignition Physics" API.
 ## Prerequisites
 
 - \ref installation "Installation"
-- \ref physicsplugin "Understand physics plugin"
+- \ref physicsplugin "Understanding the physics plugin"
 
 ## Write a simple loader
 
-We will use a simplified physics plugin example for this tutorial. Source code can be found at [ign-physics2/examples](https://github.com/ignitionrobotics/ign-physics/tree/ign-physics3/examples/hello_world_loader) folder.
+We will use a simplified physics plugin example for this tutorial. Source code can be found at [ign-physics/examples](https://github.com/ignitionrobotics/ign-physics/tree/main/examples/hello_world_loader) folder.
 
 First, create a workspace for the example plugin loader.
 
@@ -41,7 +41,7 @@ be used in our code. After the `std` C++ libraries are the `Loader.hh` and
 and plugin pointers. Next includes from \ref ignition::physics are the tools for
 retrieving \ref ignition::physics::Feature "Feature" and
 \ref ignition::physics::Entity "Entity" from physics plugins (please refer to
-\ref physicsplugin "Understand Physics Plugin" tutorial for their
+\ref physicsplugin "Understanding the physics plugin" tutorial for their
 design concepts).
 
 \snippet examples/hello_world_loader/hello_world_loader.cc include statements
@@ -55,8 +55,7 @@ available in the path using @ref ignition::plugin::Loader::Instantiate member
 function. Then for each instantiated plugin, using
 @ref ignition::physics::RequestEngine3d<Features>::From, it will request an
 engine implementing a \ref ignition::physics::FeaturePolicy "FeaturePolicy" (3D
-  in this case).
-.
+ in this case).
 
 \snippet examples/hello_world_loader/hello_world_loader.cc main
 
@@ -67,7 +66,21 @@ lines for finding `ign-plugin` and `ign-physics` dependencies in Citadel release
 After that, add the executable pointing to our file and add linking library so
 that `cmake` can compile it.
 
-\include examples/hello_world_loader/CMakeLists.txt
+[//]: # (TODO: \include does not work with .txt extension for some reason, so manually pasting this file: \include examples/hello_world_loader/CMakeLists.txt)
+```cmake
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+set(IGN_PLUGIN_VER 1)
+find_package(ignition-plugin${IGN_PLUGIN_VER} 1.1 REQUIRED COMPONENTS all)
+
+set(IGN_PHYSICS_VER 6)
+find_package(ignition-physics${IGN_PHYSICS_VER} REQUIRED)
+
+add_executable(hello_world_loader hello_world_loader.cc)
+target_link_libraries(hello_world_loader
+  ignition-plugin${IGN_PLUGIN_VER}::loader
+  ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER})
+```
 
 If you find CMake syntax difficult to understand, take a look at the official tutorial [here](https://cmake.org/cmake/help/latest/guide/tutorial/index.html).
 

--- a/tutorials/06-physics-simulation-concepts.md
+++ b/tutorials/06-physics-simulation-concepts.md
@@ -6,7 +6,7 @@ This tutorial introduces simulation concepts that are used in Ignition Physics.
 
 - \ref installation "Installation"
 - \ref physicsengine "Use different physics engines"
-- [Understand the GUI tutorial](https://ignitionrobotics.org/docs/citadel/gui)
+- [Understand the GUI tutorial](https://ignitionrobotics.org/docs/fortress/gui)
 
 ## Physics simulation features
 
@@ -19,14 +19,14 @@ Here is a snapshot of simulation features supported by ign-physics:
 Ignition adopts SDFormat structure to describe visual elements and
 also the dynamic physics aspects. To get started on SDFormat 1.7, refer to this
 [SDFormat specification](http://sdformat.org/spec?ver=1.7&elem=sdf).
-For a comprehensive tutorial for constructing your robot model from SDFormat, refer to this [Building robot](https://ignitionrobotics.org/docs/citadel/building_robot) tutorial.
+For a comprehensive tutorial for constructing your robot model from SDFormat, refer to this [Building robot](https://ignitionrobotics.org/docs/fortress/building_robot) tutorial.
 
 ## Physics concepts in Ignition Gazebo simulation
 
 In this tutorial, we will show how to
 manipulate and visualize some physics aspects using demos on Ignition Gazebo.
 
-All demos can be found in [ign-gazebo3/examples/worlds](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo3/examples/worlds/) folder.
+All demos can be found in [ign-gazebo/examples/worlds](https://github.com/ignitionrobotics/ign-gazebo/blob/main/examples/worlds/) folder.
 
 ### Differential drive
 
@@ -53,7 +53,7 @@ ign gazebo velocity_control.sdf --physics-engine ignition-physics-tpe-plugin # s
 ```
 
 To control the car movement, in a separate terminal window, we publish a
-\ref ignition::msgs::Twist "Twist" message using Ignition Transport library:
+Twist message using Ignition Transport library:
 
 ```bash
 ign topic -t "/model/vehicle_blue/cmd_vel" -m ignition.msgs.Twist -p "linear: {x: 1.0}, angular: {z: 0.5}"
@@ -65,7 +65,7 @@ This command tells the car to move in its coordinate frame with velocity
 second in Z-axis.
 
 Note that the mechanism to move the car is different depending on the used physics
-engine, see \ref physicsengine "Use different physics engine" for details on how to change physics engine used by simulation.
+engine, see \ref physicsengine "Use different physics engines" for details on how to change physics engine used by simulation.
 
 Dartsim moves the car by applying force on the joints, whereas TPE directly set velocity on the model.
 
@@ -76,7 +76,7 @@ select the drop-down list `Pose`. Moreover, we could also read the model
 links' poses relative to their parent link by selecting the
 corresponding link on the model tree:
 
-@image html img/diff_drive_link.gif
+@image html img/diff_drive_link.gif width=100%
 
 Note that using the model tree as shown in the above gif, we can view the
 parameters and properties such as `visual` or `collision` of each link or joint
@@ -89,7 +89,7 @@ Ignition Gazebo also simulates realistic collision effect. While the `vehicle_bl
 car is moving in a circle, we can move the `vehicle_green` to be on `vehicle_blue`'s
 upcoming path. The blue car will then push the green car in the following demo.
 
-@image html img/diff_drive_collision.gif
+@image html img/diff_drive_collision.gif width=100%
 
 To see where these collision parameters are set in SDFormat and how it works,
 please see this [SDFormat tutorial](http://sdformat.org/tutorials?tut=spec_shapes&cat=specification&).
@@ -110,7 +110,7 @@ ign gazebo lift_drag.sdf
 ```
 
 To see how the rotor lifts the cube due to wind force pressure, in a separate terminal window, we can publish a
-\ref ignition::msgs::Double "Double" message represeting the torque (Nm) applying to
+Double message represeting the torque (Nm) applying to
 the rotor rod axis:
 
 ```bash
@@ -126,7 +126,7 @@ ign topic -t "/model/lift_drag_demo_model/joint/rod_1_joint/cmd_force" -m igniti
 You will see the cube drops due to no lift force from support torque on the rod,
 and the blades will stop after some time due to friction.
 
-@image html img/lift_drag_torque.gif
+@image html img/lift_drag_torque.gif width=100%
 
 Several simulation features come into effect in this demo. The lift and drag force is computed by taking the wind pressure, mass of the cude, and gravity into account, and the resulting force is exerted on multiple joints. Dartsim is used to power this demo.
 
@@ -153,7 +153,7 @@ ign gazebo buoyancy.sdf
 
 After pressing the Play button, demo will run as below:
 
-@image html img/buoyancy.gif
+@image html img/buoyancy.gif width=100%
 
 The buoyancy concept is implemented by
 simulating fluid density and applying the force on the object in the fluid
@@ -180,7 +180,7 @@ After pressing the Play button, you will see that the pendulum will oscillate ar
 its main revolute joint forever due to lack of friction (it is undeclared in the
 SDFormat file).
 
-@image html img/pendulum.gif
+@image html img/pendulum.gif width=100%
 
 The oscillation period or the max angular speed of the joint
 will change if we modify the inertia of the rods. According to the demo below,
@@ -205,7 +205,7 @@ ign gazebo multicopter_velocity_control.sdf
 ```
 
 To control the multicopter to ascend and hover, in a separate terminal window, send a
-\ref ignition::msgs::Twist "Twist" message to command the `X3` multicopter
+Twist message to command the `X3` multicopter
 ascending 0.1 m.s as follow:
 
 ```bash
@@ -218,7 +218,7 @@ then hovering:
 ign topic -t "/X3/gazebo/command/twist" -m ignition.msgs.Twist -p " "
 ```
 
-@image html img/hover.gif
+@image html img/hover.gif width=100%
 
 Do the same for the `X4` multicopter. After pressing the Play button, you will see
 both of the multicopters will ascend, this demonstrates how the physics engine

--- a/tutorials/07-implementing-a-physics-plugin.md
+++ b/tutorials/07-implementing-a-physics-plugin.md
@@ -7,8 +7,8 @@ This tutorial shows how to develop a simple plugin that implements a
 ## Prerequisites
 
 - \ref installation "Installation"
-- \ref physicsplugin "Understand physics plugin"
-- \ref loadplugin "Load physics plugin"
+- \ref physicsplugin "Understanding the physics plugin"
+- \ref pluginloading "Loading physics plugins"
 
 ## Write a simple physics plugin
 
@@ -44,7 +44,7 @@ Next, we use a dummy namespace `mock` and list all the features we would like to
 
 The plugin will be able to return its physics engine metadata.
 We will now implement our plugin class named `HelloWorldPlugin`
-using the defined \ref ignition::physics::FeatureList `FeatureList` above.
+using the defined \ref ignition::physics::FeatureList "FeatureList" above.
 The class is inherited from \ref ignition::physics::Implements3d "Implements3d"
 to declare that the plugin's `HelloWorldFeatureList` will be in the 3D
 coordinate system.
@@ -53,11 +53,11 @@ coordinate system.
 
 Because we are not using a real physics engines, a dummy
 physics engines is defined inside member function `InitiateEngine` by simply setting the `engineName` to `HelloWorld`,
-and returning the engine object using \ref ignition::physics::Identity. Then, we
+and returning the engine object using `Identity`. Then, we
 define the metadata getters `GetEngineIndex` and `GetEngineName` for the
 feature \ref ignition::physics::GetEngineInfo "GetEngineInfo" (please look into
 corresponding public member functions defined in the subclasses). A list of other
-pre-defined features are can be found in the [`GetEntities` FeatureList](https://ignitionrobotics.org/api/physics/2.0/GetEntities_8hh.html).
+pre-defined features can be found in the [`GetEntities` FeatureList](https://ignitionrobotics.org/api/physics/2.0/GetEntities_8hh.html).
 
 Finally, we only have to register our plugin in Ignition Physics as a physics
 engine by:
@@ -76,7 +76,21 @@ plugin provides, i.e. `HelloWorldFeatureList`
 Now create a file named `CMakeLists.txt` with your favorite editor and add these
 lines for finding `ign-plugin` and `ign-physics` dependencies for the Fortress release:
 
-\snippet examples/hello_world_plugin/CMakeLists.txt
+[//]: # (TODO: \include does not work with .txt extension for some reason, so manually pasting this file: \include examples/hello_world_plugin/CMakeLists.txt)
+```cmake
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+set(IGN_PLUGIN_VER 1)
+find_package(ignition-plugin${IGN_PLUGIN_VER} 1.1 REQUIRED COMPONENTS all)
+
+set(IGN_PHYSICS_VER 6)
+find_package(ignition-physics${IGN_PHYSICS_VER} REQUIRED)
+
+add_library(HelloWorldPlugin SHARED HelloWorldPlugin.cc)
+target_link_libraries(HelloWorldPlugin
+  PRIVATE
+    ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER})
+```
 
 ## Build and run
 
@@ -104,7 +118,7 @@ and `HelloWorldPlugin.dll` on Windows.
 
 ### Test loading the plugin on Linux
 
-Please first follow the \ref loadplugin "Load physics plugin" tutorial
+Please first follow the \ref pluginloading "Loading physics plugins" tutorial
 to create a simple loader. Then we test our plugin using the loader as follow:
 
 ```bash

--- a/tutorials/08-implementing-a-custom-feature.md
+++ b/tutorials/08-implementing-a-custom-feature.md
@@ -3,17 +3,17 @@
 ## Prerequisites
 
 - \ref installation "Installation"
-- \ref physicsplugin "Understand physics plugin"
-- \ref loadplugin "Load physics plugin"
-- \ref implementfeature "Implement physics feature"
+- \ref physicsplugin "Understanding the physics plugin"
+- \ref pluginloading "Loading physics plugins"
+- \ref createphysicsplugin "Implement a physics feature"
 
 ## Implement a custom feature in DART plugin
 
-In the last \ref implementfeature "Implement physics feature" tutorial, we
+In the last \ref createphysicsplugin "Implement a physics feature" tutorial, we
 know how to implement a dummy physics engine as a plugin and load it using
 \ref ignition::physics "Ignition Physics API". In this tutorial, we will look
 deeper into the structure of a physics engine plugin, for example, the available
-[DART](https://github.com/ignitionrobotics/ign-physics/tree/ign-physics5/dartsim)
+[DART](https://github.com/ignitionrobotics/ign-physics/tree/main/dartsim)
 physics engine in `ign-physics` repository and how to define a custom
 \ref ignition::physics::Feature "Feature" for the plugin.
 
@@ -37,8 +37,7 @@ ign-physics
 └── CMakeLists.txt            CMake build script.
 ```
 
-As shown above, there are two physics engines available (more detail
-in \ref physicsplugin "Physics plugin tutorial"):
+As shown above, there are two physics engines available:
 - **DART**: `ignition-physics-dartsim-plugin`.
 - **TPE**: `ignition-physics-tpe-plugin`.
 
@@ -61,8 +60,7 @@ functionality of the external physics engine can be defined as a header in
 be added in a \ref ignition::physics::FeatureList "FeatureList"
 and implemented its functionalities in `src` folder.
 
-The `dartsim` plugin's \ref ignition::physics::FeatureList "FeatureList" could be
-found in \ref physicsplugin "Understand physics plugin" tutorial.
+See the \ref physicsplugin "Understanding the physics plugin" tutorial for details on physics engines.
 
 ### Plugin and feature requirements
 
@@ -136,9 +134,10 @@ will not run at the same time when requested.
 
 ### Define custom feature template
 
-With the requirements and restrictions above, we first need to define a feature template for the custom feature. In this case, this feature will be responsible for retrieving world pointer from the physics engine. The template is placed in [World.hh](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/include/ignition/physics/dartsim/World.hh):
+With the requirements and restrictions above, we first need to define a feature template for the custom feature. In this case, this feature will be responsible for retrieving world pointer from the physics engine. The template is placed in [World.hh](https://github.com/ignitionrobotics/ign-physics/blob/main/dartsim/include/ignition/physics/dartsim/World.hh):
 
-\snippet dartsim/include/ignition/physcis/dartsim/World.hh
+[//]: # (TODO: snippet does not render for some reason)
+\snippet dartsim/include/ignition/physics/dartsim/World.hh feature template
 
 The `RetrieveWorld` feature retrieves
 world pointer from physics engine, so we will use the `World` entity inherited
@@ -175,7 +174,8 @@ implement the `RetrieveWorld` feature function using Dartsim API.
 After defining the feature template, we can add it to a custom
 \ref ignition::physics::FeatureList "FeatureList":
 
-\snippet dartsim/src/CustomFeatures.hh
+[//]: # (TODO: snippet does not render for some reason)
+\snippet dartsim/src/CustomFeatures.hh add to list
 
 The custom feature `RetrieveWorld` is added to `CustomFeatureList`, other custom
 features could also be added here.
@@ -189,7 +189,8 @@ custom feature with \ref ignition::physics::FeaturePolicy3d "FeaturePolicy3d"
 We will then implement the actual function with Dartsim API in [CustomFeatures.cc](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/CustomFeatures.cc) to override the member function
 declared in the custom feature header file:
 
-\snippet dartsim/src/CustomFeatures.cc
+[//]: # (TODO: snippet does not render for some reason)
+\snippet dartsim/src/CustomFeatures.cc implementation
 
 Here, we implement the behavior of `GetDartsimWorld` with Dartsim API to return the
 world pointer from `EntityStorage` object storing world pointers of `dartsim` in
@@ -198,8 +199,8 @@ world pointer from `EntityStorage` object storing world pointers of `dartsim` in
 In the end, we add the implemented `CustomFeatures` "FeatureList" together with
 other \ref ignition::physics::FeatureList "FeatureList" to final `DartsimFeatures`
 "FeatureList" as in [dartsim/src/plugin.cc](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/plugin.cc)
-(please see \ref implementfeature "Implement physics feature" for
-registering the plugin to Ignition Physics).
+(please see the \ref createphysicsplugin "Implement a physics feature" tutorial
+for registering the plugin to Ignition Physics).
 
 The folder structure is shown below:
 


### PR DESCRIPTION
Targeting `main` because that's the version of the tutorial rendered on ignitionrobotics.org.

# 🦟 Bug fix

## Summary

- For some reason, doxygen `\include` doesn’t work with `CMakeLists.txt`. I think it doesn’t like the .txt extension, for if I copy its content to `CMakeLists.cc`, then `\include` is able to render it. So I copied the file content for now and added a TODO.
- 3 snippets from `dartsim/` are not showing in tutorial 08 for some reason. I added tags in the code, double-checked against other places that work, and still couldn’t get them to show up. It’s bizarre.

### To test

Compile the tutorials
```
colcon build --packages-select ignition-physics6 --merge-install
```

- Fix for `05_plugin_loading.md` "Loading physics plugins"
  Navigate to the current tutorial and check CMakeLists.txt snippet is missing:
  https://ignitionrobotics.org/api/physics/6.0/pluginloading.html
  Navigate in a browser to the new tutorial, filling in the prefix of this path:
  `file:///path/to/ign/build/ignition-physics6/doxygen/html/pluginloading.html`
  Check the snippet is displayed.

- Fix for `06-physics-simulation-concepts.md` “Ignition Physics simulation concepts”
  Navigate to the current tutorial and check that GIFs do not fit within screen width, and some ref links are broken:
  https://ignitionrobotics.org/api/physics/6.0/physicsconcepts.html
  Navigate in a browser to the new tutorial, filling in the prefix of this path
  `file:///path/to/ign/build/ignition-physics6/doxygen/html/physicsconcepts.html`
  Verify that the GIFs now fit within screen width. Broken links are repaired or removed.

- Fix for `07-implementing-a-physics-plugin.md` “Implement a physics feature”
  Navigate to current tutorial and check that ref links to “Load physics plugin” tutorial and `ignition::physics::Identity` are broken. Snippet for CMakeLists.txt is not showing.
  https://ignitionrobotics.org/api/physics/6.0/createphysicsplugin.html
  Check those are fixed in the new page:
  `file:///path/to/ign/build/ignition-physics6/doxygen/html/createphysicsplugin.html`

- Fix for`08-implementing-a-custom-feature.md` “Implement a custom feature”
  Some ref links are broken, 3 snippets are not displayed:
  https://ignitionrobotics.org/api/physics/5.0/createcustomfeature.html
  Check ref links are fixed in the new page
  `file:///path/to/ign/build/ignition-physics6/doxygen/html/createcustomfeature.html`

  I couldn’t fix the snippets from `dartsim`. Not sure why they don’t show up. Maybe we should copy-paste these too?
  I didn't fix these ref links:
  `\ref ignition::physics::FindFreeGroupFeature "FindFreeGroupFeature"`
  `\ref ignition::physics::Feature::Entity::Interface "Entity::Interface"`
  There aren’t API pages for these, but they’re so specific that I didn’t want to remove them in case those pages become available… Maybe I should remove them.

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [x] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**