### PR TITLE
Link to sdformat10 cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ ign_find_package(EIGEN3 REQUIRED)
 # Find SDFormat for the SDF features
 ign_find_package(sdformat10
   REQUIRED_BY sdf dartsim tpe bullet)
+set(SDFORMAT_VER ${sdformat10_VERSION_MAJOR})
 
 #--------------------------------------
 # Find dartsim for the dartsim plugin wrapper

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -2,7 +2,7 @@
 ign_add_component(sdf INTERFACE
   GET_TARGET_NAME sdf)
 
-target_link_libraries(${sdf} INTERFACE ${SDFormat_LIBRARIES})
+target_link_libraries(${sdf} INTERFACE sdformat${SDFORMAT_VER}::sdformat${SDFORMAT_VER})
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/ignitionrobotics/sdformat/pull/780

## Summary

This links to the proper cmake target for `sdformat`, which is better than using the `SDFormat_LIBRARIES` variable. That variable may be removed in https://github.com/ignitionrobotics/sdformat/pull/780, so it's good to make this change now.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
