### PR TITLE
Fix tutorial snippets with new Doxygen filters

### DIFF
--- a/tutorials/05_plugin_loading.md
+++ b/tutorials/05_plugin_loading.md
@@ -66,21 +66,7 @@ lines for finding `ign-plugin` and `ign-physics` dependencies in Citadel release
 After that, add the executable pointing to our file and add linking library so
 that `cmake` can compile it.
 
-[//]: # (TODO: \include does not work with .txt extension for some reason, so manually pasting this file: \include examples/hello_world_loader/CMakeLists.txt)
-```cmake
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
-set(IGN_PLUGIN_VER 1)
-find_package(ignition-plugin${IGN_PLUGIN_VER} 1.1 REQUIRED COMPONENTS all)
-
-set(IGN_PHYSICS_VER 6)
-find_package(ignition-physics${IGN_PHYSICS_VER} REQUIRED)
-
-add_executable(hello_world_loader hello_world_loader.cc)
-target_link_libraries(hello_world_loader
-  ignition-plugin${IGN_PLUGIN_VER}::loader
-  ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER})
-```
+\include examples/hello_world_loader/CMakeLists.txt
 
 If you find CMake syntax difficult to understand, take a look at the official tutorial [here](https://cmake.org/cmake/help/latest/guide/tutorial/index.html).
 

--- a/tutorials/07-implementing-a-physics-plugin.md
+++ b/tutorials/07-implementing-a-physics-plugin.md
@@ -76,21 +76,7 @@ plugin provides, i.e. `HelloWorldFeatureList`
 Now create a file named `CMakeLists.txt` with your favorite editor and add these
 lines for finding `ign-plugin` and `ign-physics` dependencies for the Fortress release:
 
-[//]: # (TODO: \include does not work with .txt extension for some reason, so manually pasting this file: \include examples/hello_world_plugin/CMakeLists.txt)
-```cmake
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
-set(IGN_PLUGIN_VER 1)
-find_package(ignition-plugin${IGN_PLUGIN_VER} 1.1 REQUIRED COMPONENTS all)
-
-set(IGN_PHYSICS_VER 6)
-find_package(ignition-physics${IGN_PHYSICS_VER} REQUIRED)
-
-add_library(HelloWorldPlugin SHARED HelloWorldPlugin.cc)
-target_link_libraries(HelloWorldPlugin
-  PRIVATE
-    ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER})
-```
+\include examples/hello_world_plugin/CMakeLists.txt
 
 ## Build and run
 

--- a/tutorials/08-implementing-a-custom-feature.md
+++ b/tutorials/08-implementing-a-custom-feature.md
@@ -136,7 +136,6 @@ will not run at the same time when requested.
 
 With the requirements and restrictions above, we first need to define a feature template for the custom feature. In this case, this feature will be responsible for retrieving world pointer from the physics engine. The template is placed in [World.hh](https://github.com/ignitionrobotics/ign-physics/blob/main/dartsim/include/ignition/physics/dartsim/World.hh):
 
-[//]: # (TODO: snippet does not render for some reason)
 \snippet dartsim/include/ignition/physics/dartsim/World.hh feature template
 
 The `RetrieveWorld` feature retrieves
@@ -174,7 +173,6 @@ implement the `RetrieveWorld` feature function using Dartsim API.
 After defining the feature template, we can add it to a custom
 \ref ignition::physics::FeatureList "FeatureList":
 
-[//]: # (TODO: snippet does not render for some reason)
 \snippet dartsim/src/CustomFeatures.hh add to list
 
 The custom feature `RetrieveWorld` is added to `CustomFeatureList`, other custom
@@ -189,7 +187,6 @@ custom feature with \ref ignition::physics::FeaturePolicy3d "FeaturePolicy3d"
 We will then implement the actual function with Dartsim API in [CustomFeatures.cc](https://github.com/ignitionrobotics/ign-physics/blob/ign-physics2/dartsim/src/CustomFeatures.cc) to override the member function
 declared in the custom feature header file:
 
-[//]: # (TODO: snippet does not render for some reason)
 \snippet dartsim/src/CustomFeatures.cc implementation
 
 Here, we implement the behavior of `GetDartsimWorld` with Dartsim API to return the


### PR DESCRIPTION
# 🦟 Bug fix

Followup of https://github.com/ignitionrobotics/ign-physics/pull/312
Depends on https://github.com/ignitionrobotics/ign-cmake/pull/198

## Summary

With https://github.com/ignitionrobotics/ign-cmake/pull/198 , now the snippets in tutorials 5, 7, 8 show up correctly.

Recompile
```
colcon build --packages-select ignition-physics6 ignition-cmake2 --merge-install
```
(Is it okay for this PR to target `ign-physics` `main` and that one to `ign-cmake2`? The tutorials are only fixed on `main` and not Garden. Can backport to `ign-physics5` if needed.)

Navigate to those 3 tutorials from the local page, and check that the snippets to `CMakeLists.txt`, `dartsim/*/.cc`, and `dartsim/*/.hh` are showing:
```
file:///path/to/ign/build/ignition-physics6/doxygen/html/tutorials.html
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.