### PR TITLE
Remove explicitly-defined copy constructor/operator

### DIFF
--- a/tpe/lib/src/Shape.cc
+++ b/tpe/lib/src/Shape.cc
@@ -11,7 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- *
  * limitations under the License.
  *
 */

--- a/tpe/lib/src/Shape.cc
+++ b/tpe/lib/src/Shape.cc
@@ -11,6 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
+ *
  * limitations under the License.
  *
 */
@@ -57,15 +58,6 @@ BoxShape::BoxShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-Shape &BoxShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const BoxShape *>(&_other);
-  this->size = other->size;
-  this->type = ShapeType::BOX;
-  return *this;
-}
-
-//////////////////////////////////////////////////
 void BoxShape::SetSize(const math::Vector3d &_size)
 {
   this->size = _size;
@@ -89,22 +81,6 @@ void BoxShape::UpdateBoundingBox()
 CapsuleShape::CapsuleShape() : Shape()
 {
   this->type = ShapeType::CAPSULE;
-}
-
-//////////////////////////////////////////////////
-CapsuleShape::CapsuleShape(const CapsuleShape &_other)
-  : Shape()
-{
-  *this = _other;
-}
-
-//////////////////////////////////////////////////
-Shape &CapsuleShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const CapsuleShape *>(&_other);
-  this->radius = other->radius;
-  this->length = other->length;
-  return *this;
 }
 
 //////////////////////////////////////////////////
@@ -147,15 +123,6 @@ CylinderShape::CylinderShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-Shape &CylinderShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const CylinderShape *>(&_other);
-  this->radius = other->radius;
-  this->length = other->length;
-  return *this;
-}
-
-//////////////////////////////////////////////////
 double CylinderShape::GetRadius() const
 {
   return this->radius;
@@ -195,21 +162,6 @@ EllipsoidShape::EllipsoidShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-EllipsoidShape::EllipsoidShape(const EllipsoidShape &_other)
-  : Shape()
-{
-  *this = _other;
-}
-
-//////////////////////////////////////////////////
-Shape &EllipsoidShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const EllipsoidShape *>(&_other);
-  this->radii = other->radii;
-  return *this;
-}
-
-//////////////////////////////////////////////////
 math::Vector3d EllipsoidShape::GetRadii() const
 {
   return this->radii;
@@ -236,14 +188,6 @@ SphereShape::SphereShape() : Shape()
 }
 
 //////////////////////////////////////////////////
-Shape &SphereShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const SphereShape *>(&_other);
-  this->radius = other->radius;
-  return *this;
-}
-
-//////////////////////////////////////////////////
 double SphereShape::GetRadius() const
 {
   return this->radius;
@@ -267,15 +211,6 @@ void SphereShape::UpdateBoundingBox()
 MeshShape::MeshShape() : Shape()
 {
   this->type = ShapeType::MESH;
-}
-
-//////////////////////////////////////////////////
-Shape &MeshShape::operator=(const Shape &_other)
-{
-  auto other = static_cast<const MeshShape *>(&_other);
-  this->scale = other->scale;
-  this->meshAABB = other->meshAABB;
-  return *this;
 }
 
 //////////////////////////////////////////////////

--- a/tpe/lib/src/Shape.hh
+++ b/tpe/lib/src/Shape.hh
@@ -101,10 +101,6 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE BoxShape : public Shape
   /// \brief Destructor
   public: virtual ~BoxShape() = default;
 
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
-
   /// \brief Set size of box
   /// \param[in] _size Size of box
   public: void SetSize(const math::Vector3d &_size);
@@ -128,16 +124,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE CapsuleShape : public Shape
   /// \brief Constructor
   public: CapsuleShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: CapsuleShape(const CapsuleShape &_other);
-
   /// \brief Destructor
   public: ~CapsuleShape() = default;
-
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
 
   /// \brief Get capsule radius
   /// \return capsule radius
@@ -174,10 +162,6 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE CylinderShape : public Shape
   /// \brief Destructor
   public: virtual ~CylinderShape() = default;
 
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
-
   /// \brief Get cylinder radius
   /// \return cylinder radius
   public: double GetRadius() const;
@@ -210,16 +194,8 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE EllipsoidShape : public Shape
   /// \brief Constructor
   public: EllipsoidShape();
 
-  /// \brief Copy Constructor
-  /// \param[in] _other shape to copy from
-  public: EllipsoidShape(const EllipsoidShape &_other);
-
   /// \brief Destructor
   public: ~EllipsoidShape() = default;
-
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
 
   /// \brief Get ellipsoid radius
   /// \return ellipsoid radius
@@ -247,10 +223,6 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE SphereShape : public Shape
   /// \brief Destructor
   public: virtual ~SphereShape() = default;
 
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
-
   /// \brief Get sphere radius
   /// \return Sphere radius
   public: double GetRadius() const;
@@ -274,10 +246,6 @@ class IGNITION_PHYSICS_TPELIB_VISIBLE MeshShape : public Shape
 
   /// \brief Destructor
   public: virtual ~MeshShape() = default;
-
-  /// \brief Assignment operator
-  /// \param[in] _other shape to copy from
-  public: Shape &operator=(const Shape &_other);
 
   /// \brief Set mesh
   /// \param[in] _mesh Mesh object


### PR DESCRIPTION
Cleans up warnings eg:

```
/home/mjcarroll/workspaces/ign_garden/src/ign-physics/tpe/lib/src/Shape.cc: In copy constructor ‘ignition::physics::tpelib::CapsuleShape::CapsuleShape(const ignition::physics::tpelib::CapsuleShape&)’:
/home/mjcarroll/workspaces/ign_garden/src/ign-physics/tpe/lib/src/Shape.cc:98:11: warning: implicitly-declared ‘ignition::physics::tpelib::CapsuleShape& ignition::physics::tpelib::CapsuleShape::operator=(const ignition::physics::tpelib::CapsuleShape&)’ is deprecated [-Wdeprecated-copy]
   98 |   *this = _other;
      |           ^~~~~~
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>.
