### PR TITLE
Add Ubuntu Jammy CI

### DIFF
--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,0 +1,6 @@
+libdart-collision-bullet-dev
+libdart-collision-ode-dev
+libdart-dev
+libdart-external-ikfast-dev
+libdart-external-odelcpsolver-dev
+libdart-utils-urdf-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,12 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+  jammy-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Jammy CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compile and test
+        id: ci
+        uses: ignition-tooling/action-ignition-ci@jammy


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignition-tooling/release-tools/issues/566

## Summary

Enable CI for Ubuntu 22.04 (Jammy)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
