### PR TITLE
Remove Bionic from future releases (Garden+)

### DIFF
--- a/.github/ci/packages-bionic.apt
+++ b/.github/ci/packages-bionic.apt
@@ -1,5 +1,0 @@
-dart6-data
-libdart6-collision-bullet-dev
-libdart6-collision-ode-dev
-libdart6-dev
-libdart6-utils-urdf-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
         uses: ignition-tooling/action-ignition-ci@focal
         with:
           codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,6 @@ name: Ubuntu CI
 on: [push, pull_request]
 
 jobs:
-  bionic-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Compile and test
-        id: ci
-        uses: ignition-tooling/action-ignition-ci@bionic
-        with:
-          codecov-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI
@@ -23,3 +12,5 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+        with:
+          codecov-enabled: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Build | Status
 -- | --
 Test coverage | [![codecov](https://codecov.io/gh/ignitionrobotics/ign-physics/branch/ign-physics6/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-physics)
-Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics6-bionic-amd64)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics6-bionic-amd64)
+Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics6-focal-amd64)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics6-focal-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics6-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics6-homebrew-amd64)
 Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_physics-ci-win)](https://build.osrfoundation.org/job/ign_physics-ci-win)
 

--- a/tutorials/02_installation.md
+++ b/tutorials/02_installation.md
@@ -11,9 +11,7 @@ The Source Installation instructions are generally recommended for developers wh
 
 ## Prerequisites
 
-Ignition Physics uses several C++17 features which are not available in the
-version of gcc supplied with Ubuntu Xenial, so Ubuntu Bionic or later
-is required.
+Ubuntu Focal or later.
 
 If you don't already have the `lsb-release` package installed, please do so now:
 ```
@@ -50,23 +48,13 @@ Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on w
   ```
   Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
 
-2. Use gcc-8
-  ```
-  sudo apt update
-  sudo apt-get -y install g++-8
-  sudo update-alternatives --install \
-    /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-  ```
-
-3. Clone the repository
+2. Clone the repository
   ```
   git clone https://github.com/ignitionrobotics/ign-physics -b ign-physics<#>
   ```
   Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on which version you need.
 
-4. Configure and build
+3. Configure and build
   ```
   cd ign-physics
   mkdir build
@@ -75,7 +63,7 @@ Be sure to replace `<#>` with a number value, such as `1` or `2`, depending on w
   make
   ```
 
-5. Optionally, install
+4. Optionally, install
   ```
   sudo make install
   ```


### PR DESCRIPTION
* See https://github.com/ignition-tooling/release-tools/issues/597

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

`ign-physics6` will be on Garden.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

No Bionic builds should be triggered.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
