### PR TITLE
Make CONFIG a CMake pass-through option for DART

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ignition-physics2 VERSION 2.5.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 2.8.0 REQUIRED)
+find_package(ignition-cmake2 2.12.0 REQUIRED)
 
 #============================================================================
 # Configure the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ ign_find_package(DART
     collision-ode
     utils
     utils-urdf
-  EXTRA_ARGS CONFIG
+  CONFIG
   VERSION 6.9
   REQUIRED_BY dartsim
   PKGCONFIG dart


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

# 🎉 New feature

Requires https://github.com/ignitionrobotics/ign-cmake/pull/211

## Summary
This PR makes use of https://github.com/ignitionrobotics/ign-cmake/pull/211 to revert the changes made in https://github.com/ignitionrobotics/ign-physics/pull/121. Once this is merged, it will need to be forward-ported to `ign-physics5`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.